### PR TITLE
fixes unclutter to set display and run in background, update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Additionally, an initialize option is provided to configure LXDE for Raspberry P
 
 `--password` used with local and gcom login methods
 
-`--kiosk`
+`--kiosk-mode`
   - full  (no sidebar, top navigation disabled)
   - tv (no sidebar, top navigation enabled)
   - disabled (sidebar and top navigation enabled)

--- a/pkg/initialize/lxde.go
+++ b/pkg/initialize/lxde.go
@@ -23,8 +23,9 @@ func LXDE(path string) {
 	args = []string{"s", "noblank"}
 	runCommand(path, command, args, true)
 	command = "/usr/bin/unclutter"
-	args = []string{"-display", "$DISPLAY", "-idle", "5"}
-	runCommand(path, command, args, false)
+	var displayEnv = os.Getenv("DISPLAY")
+	args = []string{"-display", displayEnv, "-idle", "5"}
+	go runCommand(path, command, args, true)
 }
 
 func runCommand(path string, command string, args []string, waitForEnd bool) {

--- a/pkg/kiosk/anonymous_login.go
+++ b/pkg/kiosk/anonymous_login.go
@@ -57,10 +57,10 @@ func GrafanaKioskAnonymous(urlPtr *string, kioskMode int, autoFit *bool, isPlayL
 	time.Sleep(2000 * time.Millisecond)
 
 	var generatedURL = GenerateURL(*urlPtr, kioskMode, autoFit, isPlayList)
+	log.Println("Navigating to ", generatedURL)
 	/*
 		Launch chrome and look for main-view element
 	*/
-	log.Println("Navigating to ", generatedURL)
 	if err := chromedp.Run(taskCtx,
 		chromedp.Navigate(generatedURL),
 		chromedp.WaitVisible("//div[@class=\"main-view\"]", chromedp.BySearch),

--- a/pkg/kiosk/grafana_com_login.go
+++ b/pkg/kiosk/grafana_com_login.go
@@ -46,6 +46,7 @@ func GrafanaKioskGCOM(urlPtr *string, usernamePtr *string, passwordPtr *string, 
 	}
 
 	var generatedURL = GenerateURL(*urlPtr, kioskMode, autoFit, isPlayList)
+	log.Println("Navigating to ", generatedURL)
 
 	/*
 		Launch chrome, click the grafana.com button, fill out login form and submit

--- a/pkg/kiosk/local_login.go
+++ b/pkg/kiosk/local_login.go
@@ -46,6 +46,7 @@ func GrafanaKioskLocal(urlPtr *string, usernamePtr *string, passwordPtr *string,
 	}
 
 	var generatedURL = GenerateURL(*urlPtr, kioskMode, autoFit, isPlayList)
+	log.Println("Navigating to ", generatedURL)
 	/*
 		Launch chrome and login with local user account
 

--- a/pkg/kiosk/utils.go
+++ b/pkg/kiosk/utils.go
@@ -13,15 +13,9 @@ func GenerateURL(anURL string, kioskMode int, autoFit *bool, isPlayList *bool) s
 	case 0: // TV
 		q.Set("kiosk", "tv") // no sidebar, topnav without buttons
 		log.Printf("KioskMode: TV")
-		if *autoFit == true {
-			q.Set("autofitpanels", "1") // scale panels to fill screen
-		}
 	case 1: // FULLSCREEN
 		q.Set("kiosk", "1") // sidebar and topnav always shown
 		log.Printf("KioskMode: Fullscreen")
-		if *autoFit == true {
-			q.Set("autofitpanels", "1") // scale panels to fill screen
-		}
 	default: // disabled
 		log.Printf("KioskMode: Disabled")
 	}
@@ -30,5 +24,8 @@ func GenerateURL(anURL string, kioskMode int, autoFit *bool, isPlayList *bool) s
 		q.Set("inactive", "1")
 	}
 	u.RawQuery = q.Encode()
+	if *autoFit == true {
+		u.RawQuery = u.RawQuery + "&autofitpanels"
+	}
 	return u.String()
 }


### PR DESCRIPTION
- unclutter for LXDE option should run in background (as go routine)
- update usage doc
- separate autofit

With --LXDE option on Linux the mouse will be automatically hidden.