### PR TITLE
Makefile: Add arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ grafana-kiosk: dev
 	GOOS=linux GOARCH=arm GOARM=5 go build -o bin/grafana-kiosk.linux.armv5 pkg/cmd/grafana-kiosk/main.go
 	GOOS=linux GOARCH=arm GOARM=6 go build -o bin/grafana-kiosk.linux.armv6 pkg/cmd/grafana-kiosk/main.go
 	GOOS=linux GOARCH=arm GOARM=7 go build -o bin/grafana-kiosk.linux.armv7 pkg/cmd/grafana-kiosk/main.go
+	GOOS=linux GOARCH=arm64 go build -o bin/grafana-kiosk.linux.arm64 pkg/cmd/grafana-kiosk/main.go
 
 test-circleci:
 	@echo "Testing build in circleci"


### PR DESCRIPTION
Go supports compiling to arm 64-bit, which is useful on Raspberry Pi 4 and other new ARM devices.

Note that I didn't commit the binary I produced locally. For security/trust reasons, I think it's better that the maintainer of this project publishes binaries.