### PR TITLE
reload chrome tab when it crashes (e.g. out of JS memory)

### DIFF
--- a/pkg/kiosk/anonymous_login.go
+++ b/pkg/kiosk/anonymous_login.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/chromedp"
 )
 
@@ -39,15 +38,9 @@ func GrafanaKioskAnonymous(urlPtr *string, kioskMode int, autoFit *bool, isPlayL
 	// also set up a custom logger
 	taskCtx, cancel := chromedp.NewContext(allocCtx, chromedp.WithLogf(log.Printf))
 	defer cancel()
-	chromedp.ListenTarget(taskCtx, func(ev interface{}) {
-		switch ev := ev.(type) {
-		case *runtime.EventConsoleAPICalled:
-			log.Printf("console.%s call:\n", ev.Type)
-			for _, arg := range ev.Args {
-				log.Printf("%s - %s\n", arg.Type, arg.Value)
-			}
-		}
-	})
+
+	listenChromeEvents(taskCtx, consoleAPICall|targetCrashed)
+
 	// ensure that the browser process is started
 	if err := chromedp.Run(taskCtx); err != nil {
 		panic(err)

--- a/pkg/kiosk/grafana_com_login.go
+++ b/pkg/kiosk/grafana_com_login.go
@@ -40,6 +40,8 @@ func GrafanaKioskGCOM(urlPtr *string, usernamePtr *string, passwordPtr *string, 
 	taskCtx, cancel := chromedp.NewContext(allocCtx, chromedp.WithLogf(log.Printf))
 	defer cancel()
 
+	listenChromeEvents(taskCtx, targetCrashed)
+
 	// ensure that the browser process is started
 	if err := chromedp.Run(taskCtx); err != nil {
 		panic(err)

--- a/pkg/kiosk/listen_chrome_events.go
+++ b/pkg/kiosk/listen_chrome_events.go
@@ -1,0 +1,38 @@
+package kiosk
+
+import (
+	"context"
+	"log"
+
+	"github.com/chromedp/cdproto/inspector"
+	"github.com/chromedp/cdproto/runtime"
+	"github.com/chromedp/chromedp"
+)
+
+type chromeEvents int
+
+const (
+	consoleAPICall chromeEvents = 1 << iota
+	targetCrashed
+)
+
+func listenChromeEvents(taskCtx context.Context, events chromeEvents) {
+	chromedp.ListenTarget(taskCtx, func(ev interface{}) {
+		switch ev := ev.(type) {
+		case *runtime.EventConsoleAPICalled:
+			if events&consoleAPICall != 0 {
+				log.Printf("console.%s call:\n", ev.Type)
+				for _, arg := range ev.Args {
+					log.Printf("	%s - %s\n", arg.Type, arg.Value)
+				}
+			}
+		case *inspector.EventTargetCrashed:
+			if events&targetCrashed != 0 {
+				log.Printf("target crashed, reload...")
+				go func() {
+					chromedp.Run(taskCtx, chromedp.Reload())
+				}()
+			}
+		}
+	})
+}

--- a/pkg/kiosk/local_login.go
+++ b/pkg/kiosk/local_login.go
@@ -40,6 +40,8 @@ func GrafanaKioskLocal(urlPtr *string, usernamePtr *string, passwordPtr *string,
 	taskCtx, cancel := chromedp.NewContext(allocCtx, chromedp.WithLogf(log.Printf))
 	defer cancel()
 
+	listenChromeEvents(taskCtx, targetCrashed)
+
 	// ensure that the browser process is started
 	if err := chromedp.Run(taskCtx); err != nil {
 		panic(err)


### PR DESCRIPTION
Workaround for a panel we use that may have a memory leak, causing chrome to kill the tab with the dashboard after some time.

This will listen to the chromedp `inspector.EventTargetCrashed` event and reloads the tab.

I can add a cli flag for enabling this behaviour if you prefer