### PR TITLE
new docs for autostarting kiosk as a service/background process

### DIFF
--- a/scripts/grafana-kiosk.service
+++ b/scripts/grafana-kiosk.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Grafana Kiosk
+Documentation=https://github.com/grafana/grafana-kiosk
+Documentation=https://grafana.com/blog/2019/05/02/grafana-tutorial-how-to-create-kiosks-to-display-dashboards-on-a-tv
+After=network.target
+
+[Service]
+User=pi
+Environment="DISPLAY=:0"
+Environment="XAUTHORITY=/home/pi/.Xauthority"
+ExecStart=/usr/bin/grafana-kiosk --URL <url>  -login-method local -username <username> -password <password> -playlist true
+
+[Install]
+WantedBy=graphical.target


### PR DESCRIPTION
This adds several methods for starting a kiosk, with a focus on LXDE on a pi.
