### PR TITLE
Add an option to ignore certificate errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ $ sudo cp -p grafana-kiosk.linux.armv7 /usr/bin/grafana-kiosk
 
 `--password` used with local and gcom login methods
 
+`--ignore-certificate-errors` used with local and anonymous login methods
+
 `--kiosk-mode`
 
 - full  (no sidebar, top navigation disabled)
@@ -106,8 +108,10 @@ This will login to a grafana server that uses local accounts:
 ./bin/grafana-kiosk --URL https://localhost:3000 --login-method local --username admin --password admin --kiosk-mode tv
 ```
 
+If you are using a self-signed certificate, you can remove the certificate error with `--ignore-certificate-errors`
+
 ```bash
-./bin/grafana-kiosk --URL https://localhost:3000 --login-method local --username admin --password admin --kiosk-mode tv
+./bin/grafana-kiosk --URL https://localhost:3000 --login-method local --username admin --password admin --kiosk-mode tv --ignore-certificate-errors
 ```
 
 ### Grafana Server with Anonymous access enabled

--- a/pkg/cmd/grafana-kiosk/main.go
+++ b/pkg/cmd/grafana-kiosk/main.go
@@ -66,6 +66,7 @@ func main() {
 	methodPtr := flag.String("login-method", "anon", "login method: [anon|local|gcom]")
 	usernamePtr := flag.String("username", "guest", "username (Required)")
 	passwordPtr := flag.String("password", "guest", "password (Required)")
+	ignoreCertificateErrors := flag.Bool("ignore-certificate-errors", false, "ignore SSL/TLS certificate errors")
 	// kiosk=tv includes sidebar menu
 	// kiosk no sidebar ever
 	kioskModePtr := flag.String("kiosk-mode", "full", "kiosk mode [full|tv|disabled]")
@@ -123,12 +124,12 @@ func main() {
 	switch loginMethod {
 	case LOCAL:
 		log.Printf("Launching local login kiosk")
-		kiosk.GrafanaKioskLocal(urlPtr, usernamePtr, passwordPtr, kioskMode, autoFit, isPlayList)
+		kiosk.GrafanaKioskLocal(urlPtr, usernamePtr, passwordPtr, kioskMode, autoFit, isPlayList, ignoreCertificateErrors)
 	case GCOM:
 		log.Printf("Launching GCOM login kiosk")
 		kiosk.GrafanaKioskGCOM(urlPtr, usernamePtr, passwordPtr, kioskMode, autoFit, isPlayList)
 	case ANONYMOUS:
 		log.Printf("Launching ANON login kiosk")
-		kiosk.GrafanaKioskAnonymous(urlPtr, kioskMode, autoFit, isPlayList)
+		kiosk.GrafanaKioskAnonymous(urlPtr, kioskMode, autoFit, isPlayList, ignoreCertificateErrors)
 	}
 }

--- a/pkg/kiosk/anonymous_login.go
+++ b/pkg/kiosk/anonymous_login.go
@@ -11,7 +11,7 @@ import (
 )
 
 // GrafanaKioskAnonymous creates a chrome-based kiosk using a local grafana-server account
-func GrafanaKioskAnonymous(urlPtr *string, kioskMode int, autoFit *bool, isPlayList *bool) {
+func GrafanaKioskAnonymous(urlPtr *string, kioskMode int, autoFit *bool, isPlayList *bool, ignoreCertificateErrors *bool) {
 	dir, err := ioutil.TempDir("", "chromedp-example")
 	if err != nil {
 		panic(err)
@@ -29,6 +29,8 @@ func GrafanaKioskAnonymous(urlPtr *string, kioskMode int, autoFit *bool, isPlayL
 		chromedp.Flag("disable-sync", true),
 		chromedp.Flag("disable-notifications", true),
 		chromedp.Flag("disable-overlay-scrollbar", true),
+		chromedp.Flag("ignore-certificate-errors", *ignoreCertificateErrors),
+		chromedp.Flag("test-type", *ignoreCertificateErrors),
 		chromedp.UserDataDir(dir),
 	}
 

--- a/pkg/kiosk/local_login.go
+++ b/pkg/kiosk/local_login.go
@@ -12,7 +12,7 @@ import (
 )
 
 // GrafanaKioskLocal creates a chrome-based kiosk using a local grafana-server account
-func GrafanaKioskLocal(urlPtr *string, usernamePtr *string, passwordPtr *string, kioskMode int, autoFit *bool, isPlayList *bool) {
+func GrafanaKioskLocal(urlPtr *string, usernamePtr *string, passwordPtr *string, kioskMode int, autoFit *bool, isPlayList *bool, ignoreCertificateErrors *bool) {
 	dir, err := ioutil.TempDir("", "chromedp-example")
 	if err != nil {
 		panic(err)
@@ -30,6 +30,8 @@ func GrafanaKioskLocal(urlPtr *string, usernamePtr *string, passwordPtr *string,
 		chromedp.Flag("disable-sync", true),
 		chromedp.Flag("disable-notifications", true),
 		chromedp.Flag("disable-overlay-scrollbar", true),
+		chromedp.Flag("ignore-certificate-errors", *ignoreCertificateErrors),
+		chromedp.Flag("test-type", *ignoreCertificateErrors),
 		chromedp.UserDataDir(dir),
 	}
 


### PR DESCRIPTION
Fixes #25

The flag `-ignore-certificate-errors` has been added which will ignore
issues with SSL/TLS certificates (such as self-signed and expired
certs).

This will only work on anonymous and local login types as invalid
certificates for grafana.com should never be ignored.

## Testing instructions

  1. Run `make` to generate the binaries
  1. Run the following command to launch a sample dashboard with a bad SSL certificate

     ```bash
     ./bin/grafana-kiosk.$OS.$ARCH --URL https://badgraph.pyrat.uk/d/TXSTREZ/simple-streaming-example
     ```
  1. Run the following command to launch with `--ignore-certificate-errors`

     ```bash
     ./bin/grafana-kiosk.$OS.$ARCH --URL https://badgraph.pyrat.uk/d/TXSTREZ/simple-streaming-example --ignore-certificate-errors
     ```

## Expected results

  1. The build will complete
  1. You should see a warning about your connection not being private.

     ![Screenshot from 2020-03-07 10-08-21](https://user-images.githubusercontent.com/244186/76141407-cadd1b80-605b-11ea-9639-31f2e1cac1ae.png)

  1. You should see the dashboard be displayed.

     ![Screenshot from 2020-03-07 10-08-59](https://user-images.githubusercontent.com/244186/76141410-d7fa0a80-605b-11ea-93a7-ef017e693219.png)
