### PR TITLE
add generic oauth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ They can also be used instead of a configuration file.
       URL to Grafana server (default "https://play.grafana.org")
   KIOSK_LOGIN_USER string
       username (default "guest")
+  KIOSK_GOAUTH_AUTO_LOGIN bool
+      IF oauth_auto_login setting is set to true or false in grafana config (default "false")
+  KIOSK_GOAUTH_FIELD_USER string
+      HTML input fieldname value for username of your generic oauth provider (default "test")
+  KIOSK_GOAUTH_FIELD_PASSWORD string
+      HTML input fieldname value for the password of your generic oauth provider (default "test")
 ```
 
 ### Hosted Grafana using grafana.com authentication
@@ -178,6 +184,26 @@ This will take the browser to a playlist on play.grafana.org in fullscreen kiosk
 
 ```bash
 ./bin/grafana-kiosk --URL https://play.grafana.org/playlists/play/1 --login-method anon --kiosk-mode tv
+```
+
+### Grafana Server with Generic Oauth
+
+This will login to a Generic Oauth service, configured on Grafana. Oauth_auto_login is disabeld. As Oauth provider is Keycloak used.
+
+```bash
+go run pkg/cmd/grafana-kiosk/main.go --URL https://my.grafana.oauth/playlists/play/1  --login-method goauth --username test --password test
+```
+
+This will login to a Generic Oauth service, configured on Grafana. Oauth_auto_login is disabeld. As Oauth provider is Keycloak used and also the login and password html input name is set.
+
+```bash
+go run pkg/cmd/grafana-kiosk/main.go --URL https://my.grafana.oauth/playlists/play/1 --login-method goauth --username test --password test --field-username username --field-password password
+```
+
+This will login to a Generic Oauth service, configured on Grafana. Oauth_auto_login is enabled. As Oauth provider is Keycloak used and also the login and password html input name is set.
+
+```bash
+go run pkg/cmd/grafana-kiosk/main.go --URL https://my.grafana.oauth/playlists/play/1 --login-method goauth --username test --password test --field-username username --field-password password --auto-login true
 ```
 
 ## LXDE Options

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -11,3 +11,8 @@ target:
   playlist: false
   URL: https://play.grafana.org
   ignore-certificate-errors: false
+
+goauth:
+  auto-login: false
+  fieldname-username: username
+  fieldname-password: password

--- a/pkg/kiosk/config.go
+++ b/pkg/kiosk/config.go
@@ -11,9 +11,14 @@ type Config struct {
 	Target struct {
 		IgnoreCertificateErrors bool   `yaml:"ignore-certificate-errors" env:"KIOSK_IGNORE_CERTIFICATE_ERRORS" env-description:"ignore SSL/TLS certificate errors" env-default:"false"`
 		IsPlayList              bool   `yaml:"playlist" env:"KIOSK_IS_PLAYLIST" env-default:"false" env-description:"URL is a playlist"`
-		LoginMethod             string `yaml:"login-method" env:"KIOSK_LOGIN_METHOD" env-default:"anon" env-description:"[anon|local|gcom]"`
+		LoginMethod             string `yaml:"login-method" env:"KIOSK_LOGIN_METHOD" env-default:"anon" env-description:"[anon|local|gcom|goauth]"`
 		Password                string `yaml:"password" env:"KIOSK_LOGIN_PASSWORD" env-default:"guest" env-description:"password"`
 		URL                     string `yaml:"URL" env:"KIOSK_URL" env-default:"https://play.grafana.org" env-description:"URL to Grafana server"`
 		Username                string `yaml:"username" env:"KIOSK_LOGIN_USER" env-default:"guest" env-description:"username"`
 	} `yaml:"target"`
+	GOAUTH struct {
+		AutoLogin     bool   `yaml:"auto-login" env:"KIOSK_GOAUTH_AUTO_LOGIN" env-description:"[false|true]"`
+		UsernameField string `yaml:"fieldname-username" env:"KIOSK_GOAUTH_FIELD_USER" env-description:"Username html input name value"`
+		PasswordField string `yaml:"fieldname-password" env:"KIOSK_GOAUTH_FIELD_PASSWORD" env-description:"Password html input name value"`
+	} `yaml:"goauth"`
 }

--- a/pkg/kiosk/grafana_genericoauth_login.go
+++ b/pkg/kiosk/grafana_genericoauth_login.go
@@ -1,0 +1,87 @@
+package kiosk
+
+import (
+	"context"
+	"io/ioutil"
+	"log"
+	"os"
+	"time"
+
+	"github.com/chromedp/chromedp"
+	"github.com/chromedp/chromedp/kb"
+)
+
+// GrafanaKioskGenericOauth creates a chrome-based kiosk using a oauth2 authenticated account
+func GrafanaKioskGenericOauth(cfg *Config) {
+	dir, err := ioutil.TempDir("", "chromedp-example")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+
+	opts := []chromedp.ExecAllocatorOption{
+		chromedp.NoFirstRun,
+		chromedp.NoDefaultBrowserCheck,
+		// chromedp.DisableGPU, // needed?
+		chromedp.Flag("noerrdialogs", true),
+		chromedp.Flag("kiosk", true),
+		chromedp.Flag("bwsi", true),
+		chromedp.Flag("incognito", true),
+		chromedp.Flag("disable-sync", true),
+		chromedp.Flag("disable-notifications", true),
+		chromedp.Flag("disable-overlay-scrollbar", true),
+		chromedp.UserDataDir(dir),
+	}
+
+	allocCtx, cancel := chromedp.NewExecAllocator(context.Background(), opts...)
+	defer cancel()
+
+	// also set up a custom logger
+	taskCtx, cancel := chromedp.NewContext(allocCtx, chromedp.WithLogf(log.Printf))
+	defer cancel()
+
+	listenChromeEvents(taskCtx, targetCrashed)
+
+	// ensure that the browser process is started
+	if err := chromedp.Run(taskCtx); err != nil {
+		panic(err)
+	}
+
+	var generatedURL = GenerateURL(cfg.Target.URL, cfg.General.Mode, cfg.General.AutoFit, cfg.Target.IsPlayList)
+	log.Println("Navigating to ", generatedURL)
+
+	/*
+		Launch chrome, click the GENERIC OAUTH button, fill out login form and submit
+	*/
+	// XPATH of grafana.com for Generic OAUTH login button = //*[@href="login/grafana_com"]/i
+
+	// Click the OAUTH login button
+	log.Println("Oauth_Auto_Login enabeld: ", cfg.GOAUTH.AutoLogin)
+	if cfg.GOAUTH.AutoLogin {
+		if err := chromedp.Run(taskCtx,
+			chromedp.Navigate(generatedURL),
+		); err != nil {
+			panic(err)
+		}
+	} else {
+		if err := chromedp.Run(taskCtx,
+			chromedp.Navigate(generatedURL),
+			chromedp.WaitVisible(`//*[@href="login/generic_oauth"]`, chromedp.BySearch),
+			chromedp.Click(`//*[@href="login/generic_oauth"]`, chromedp.BySearch),
+		); err != nil {
+			panic(err)
+		}
+	}
+
+	// Give browser time to load next page (this can be prone to failure, explore different options vs sleeping)
+	time.Sleep(2000 * time.Millisecond)
+	// Fill out OAUTH login page
+	if err := chromedp.Run(taskCtx,
+		chromedp.WaitVisible(`//input[@name="`+cfg.GOAUTH.UsernameField+`"]`, chromedp.BySearch),
+		chromedp.SendKeys(`//input[@name="`+cfg.GOAUTH.UsernameField+`"]`, cfg.Target.Username, chromedp.BySearch),
+		chromedp.SendKeys(`//input[@name="`+cfg.GOAUTH.PasswordField+`"]`, cfg.Target.Password+kb.Enter, chromedp.BySearch),
+		chromedp.WaitVisible(`notinputPassword`, chromedp.ByID),
+	); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
## changes

- generic oauth login
- flag for oauth_auto_login true|false
- variable for input field username of generic oauth provider
- variable for input field password of generic oauth provider
- added sample bash command in doc (url wan't work out of the box, since i used a local instance to test it)

made a own category in the config yaml, that it's not mixed up with the gcom or local login methods

For testing, i used Keycloak 10.0.1 as oauth provider with Grafana 7.3.2.