### PR TITLE
add `autoplay-policy` option to chromedp flags

### DIFF
--- a/pkg/kiosk/utils.go
+++ b/pkg/kiosk/utils.go
@@ -53,6 +53,7 @@ func generateExecutorOptions(dir string, windowPosition string, ignoreCertificat
 		chromedp.Flag("check-for-update-interval", "31536000"),
 		chromedp.Flag("ignore-certificate-errors", ignoreCertificateErrors),
 		chromedp.Flag("test-type", ignoreCertificateErrors),
+		chromedp.Flag("autoplay-policy", "no-user-gesture-required"),
 		chromedp.UserDataDir(dir),
 	}
 }


### PR DESCRIPTION
Hi, I would like to make one suggestion regarding the Chrome startup flag when grafana-kiosk starts.

## Problems

Currently, I am trying to use a video plugin to play YouTube videos on my grafana-kiosk dashboard.

- [Video plugin for Grafana | Grafana Labs](https://grafana.com/grafana/plugins/innius-video-panel/) 

However, Chrome has an [Autoplay policy](https://developer.chrome.com/blog/autoplay/#new-behaviors), and if I want to autoplay videos embedded in `<iframe>` or `<video>` tags, I need to satisfy [the following conditions](https://developer.chrome.com/blog/autoplay/#new-behaviors) beforehand.

> - Muted autoplay is always allowed.
> - Autoplay with sound is allowed if:
>   - The user has interacted with the domain (click, tap, etc.).
>   - On desktop, the user's [Media Engagement Index](https://developer.chrome.com/blog/autoplay/#media-engagement-index) threshold has been crossed, meaning the user has previously played video with sound.
>   - The user has [added the site to their home screen](https://web.dev/customize-install/) on mobile or [installed the PWA](https://web.dev/progressive-web-apps/) on desktop.
> - Top frames can [delegate autoplay permission](https://developer.chrome.com/blog/autoplay/#iframe-delegation) to their iframes to allow autoplay with sound.

It is very difficult to satisfy these conditions stably with the current grafana-kiosk, that is, to make videos play in the intended state. In the first place, [grafana-kiosk starts Chrome in Incognito mode](https://github.com/grafana/grafana-kiosk/blob/4257cb9ed74b8285debcab46f1ac79caa3488b01/pkg/kiosk/utils.go#L48), so it is not possible to avoid this problem by improving Chrome's [MEI (Media Engagement Index)](https://developer.chrome.com/blog/autoplay/#media-engagement-index) even after playing videos several times.

## Suggestion

I would like to set the flag `--autoplay-policy=no-user-gesture-required` introduced above as the default flag when Chrome starts. By enabling this flag, videos specified in Grafana will be able to play regardless of the policy on the Chrome side.

- [Autoplay policy in Chrome # Developer switches](https://developer.chrome.com/blog/autoplay/#developer-switches)

## Concerns

Setting this flag may cause problems, such as increased network data consumption, as videos are automatically loaded. However, when specifying a video, the dashboard administrator can disable autoplay in advance via an iframe or plugin option. Of course, the dashboard administrator has the authority to set the URL to load, so there should be no unintended URLs being called. Therefore, I believe the benefits of setting this flag outweigh any concerns.

Thank you in advance for your consideration of the above.