### PR TITLE
fix autofit logic

### DIFF
--- a/pkg/kiosk/utils.go
+++ b/pkg/kiosk/utils.go
@@ -31,10 +31,15 @@ func GenerateURL(anURL string, kioskMode string, autoFit bool, isPlayList bool) 
 	if isPlayList {
 		parsedQuery.Set("inactive", "1")
 	}
-	if autoFit {
-		parsedQuery.Set("autofitpanels", "")
-	}
 	parsedURI.RawQuery = parsedQuery.Encode()
+	// grafana is not parsing autofitpanels that uses an equals sign, so leave it out
+	if autoFit {
+		if len(parsedQuery) > 0 {
+			parsedURI.RawQuery += "&autofitpanels"
+		} else {
+			parsedURI.RawQuery += "autofitpanels"
+		}
+	}
 
 	return parsedURI.String()
 }

--- a/pkg/kiosk/utils_test.go
+++ b/pkg/kiosk/utils_test.go
@@ -11,19 +11,23 @@ func TestGenerateURL(t *testing.T) {
 	Convey("Given URL params", t, func() {
 		Convey("Fullscreen Anonymous Login", func() {
 			anURL := GenerateURL("https://play.grafana/com", "full", true, false)
-			So(anURL, ShouldEqual, "https://play.grafana/com?autofitpanels=&kiosk=1")
+			So(anURL, ShouldEqual, "https://play.grafana/com?kiosk=1&autofitpanels")
 		})
 		Convey("TV Mode Anonymous Login", func() {
 			anURL := GenerateURL("https://play.grafana/com", "tv", true, false)
-			So(anURL, ShouldEqual, "https://play.grafana/com?autofitpanels=&kiosk=tv")
+			So(anURL, ShouldEqual, "https://play.grafana/com?kiosk=tv&autofitpanels")
 		})
 		Convey("Not Fullscreen Anonymous Login", func() {
 			anURL := GenerateURL("https://play.grafana/com", "disabled", true, false)
-			So(anURL, ShouldEqual, "https://play.grafana/com?autofitpanels=")
+			So(anURL, ShouldEqual, "https://play.grafana/com?autofitpanels")
 		})
 		Convey("Default Kiosk Anonymous Login", func() {
 			anURL := GenerateURL("https://play.grafana/com", "", false, false)
 			So(anURL, ShouldEqual, "https://play.grafana/com?kiosk=1")
+		})
+		Convey("Default Anonymous Login with autofit", func() {
+			anURL := GenerateURL("https://play.grafana/com", "disabled", true, false)
+			So(anURL, ShouldEqual, "https://play.grafana/com?autofitpanels")
 		})
 	})
 }


### PR DESCRIPTION
Grafana doesn't parse `autofitpanels=` correctly, it only expects `autofitpanels` with no equals or value.

this detects if there are params set, and appends as necessary.

Along with WindowSize and AutoFitPanels, the kiosk works on smaller displays like a 7" touchscreen (1024x600 resolution) and scales the panels as intended.