### PR TITLE
Switch to deep checkout needed for release action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v3


### PR DESCRIPTION
softprops/action-gh-release@v1 needs the whole history (or at least until the last tag) to create Change Log and Releases. The checkout action v3 per default only gets the latest commit, which makes the release action fail.

Add the setting for a full checkout to support release building.