### PR TITLE
Set flag to disable translator overlay

### DIFF
--- a/pkg/kiosk/utils.go
+++ b/pkg/kiosk/utils.go
@@ -61,6 +61,7 @@ func generateExecutorOptions(dir string, cfg *Config) []chromedp.ExecAllocatorOp
 		chromedp.Flag("disable-sync", true),
 		chromedp.Flag("disable-notifications", true),
 		chromedp.Flag("disable-overlay-scrollbar", true),
+		chromedp.Flag("disable-features", "Translate"),
 		chromedp.Flag("window-position", cfg.General.WindowPosition),
 		chromedp.Flag("check-for-update-interval", "31536000"),
 		chromedp.Flag("ignore-certificate-errors", cfg.Target.IgnoreCertificateErrors),


### PR DESCRIPTION
On my system the Google translate overlay was displayed permanently over the graphs. For me this was very annoying and this fixes it.