### PR TITLE
Fix passing of scale factor

### DIFF
--- a/pkg/cmd/grafana-kiosk/main.go
+++ b/pkg/cmd/grafana-kiosk/main.go
@@ -185,6 +185,7 @@ func main() {
 		cfg.General.Mode = args.Mode
 		cfg.General.WindowPosition = args.WindowPosition
 		cfg.General.WindowSize = args.WindowSize
+		cfg.General.ScaleFactor = args.ScaleFactor
 		//
 		cfg.GoAuth.AutoLogin = args.OauthAutoLogin
 		cfg.GoAuth.UsernameField = args.UsernameField


### PR DESCRIPTION
Pass scale factor if used as a command line variable. Currently, `-scale-factor` is accepted as a command line variable, but not properly passed to the config and therefore not applied.