### PR TITLE
Fix run:local and build:local Mage targets on Linux and Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/
 coverage/
+.idea

--- a/Magefile.go
+++ b/Magefile.go
@@ -117,13 +117,13 @@ func buildCommand(command string, arch string) error {
 		return err
 	}
 
-	// intentionally igores errors
+	// intentionally ignores errors
 	sh.RunV("chmod", "+x", outDir)
 	return nil
 }
 
 func kioskCmd() error {
-	return buildCommand("grafana-kiosk", "darwin_amd64")
+	return buildCommand("grafana-kiosk", runtime.GOOS+"_"+runtime.GOARCH)
 }
 
 func buildCmdAll() error {
@@ -236,7 +236,7 @@ func (Run) Local() error {
 	mg.Deps(Build.Local)
 	return sh.RunV(
 		"./bin/"+runtime.GOOS+"_"+runtime.GOARCH+"/grafana-kiosk",
-		"-config",
+		"-c",
 		"config-example.yaml",
 	)
 }


### PR DESCRIPTION
Small fix to the Magefile which didn't work on Linux.

Also changes the flag in `run:local` to use `-c` flag instead of `-config` (the name was wrong, the flag is defined here:)

https://github.com/grafana/grafana-kiosk/blob/19dc76d94bf7dbca125c249ddf46428f45cd9eb6/pkg/cmd/grafana-kiosk/main.go#L52