### PR TITLE
Accept cookies for aws grafana automatically

### DIFF
--- a/pkg/kiosk/aws_login.go
+++ b/pkg/kiosk/aws_login.go
@@ -49,6 +49,8 @@ func GrafanaKioskAWSLogin(cfg *Config, messages chan string) {
 	if err := chromedp.Run(taskCtx,
 		chromedp.Navigate(generatedURL),
 		chromedp.WaitVisible(`//a[contains(@href,'login/sso')]`, chromedp.BySearch),
+		chromedp.WaitVisible(`div#awsccc-cb-buttons`, chromedp.BySearch),
+		chromedp.Click(`//button[contains(@data-id,'awsccc-cb-btn-accept')]`, chromedp.BySearch),
 		chromedp.Click(`//a[contains(@href,'login/sso')]`, chromedp.BySearch),
 		chromedp.WaitVisible(`input#awsui-input-0`, chromedp.BySearch),
 		chromedp.SendKeys(`input#awsui-input-0`, cfg.Target.Username+kb.Enter, chromedp.BySearch),


### PR DESCRIPTION
This PR fixes issue #129 by accepting the cookie banner for the aws login method (it is aws specific).

We needed to do this. I'm not sure this is the best way to do it, first time using go and puppeteer, this works for us.