### PR TITLE
add small update to readme configuration file section for apikey

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ target:
   playlist: false
   URL: https://play.grafana.org
   ignore-certificate-errors: false
+
+# API Authentication
+#apikey:
+#  apikey: <grafana apikey>
 ```
 
 ```BASH


### PR DESCRIPTION
Completed a Grafana Kiosk reinstall/migration to a new device today with the latest binary. Based on my original systemd based configuration, decided to migrate to the config.yaml style approach. 

When attempting apikey authentication, the README is slightly unclear. Updated to include the proper keys in the config.yaml example to allow for apikey based authentication.

https://github.com/grafana/grafana-kiosk/issues/110#issuecomment-1770071511 - thanks to everyone for documenting it before I had to dive into the codebase