### PR TITLE
Click "Yes" in "Stay signed in" page when using microsoft login

### DIFF
--- a/pkg/cmd/grafana-kiosk/main.go
+++ b/pkg/cmd/grafana-kiosk/main.go
@@ -26,6 +26,7 @@ type Args struct {
 	OauthAutoLogin                       bool
 	OauthWaitForPasswordField            bool
 	OauthWaitForPasswordFieldIgnoreClass string
+	OauthWaitForStaySignedInPrompt       bool
 	LXDEEnabled                          bool
 	UseMFA                               bool
 	Audience                             string
@@ -70,6 +71,7 @@ func ProcessArgs(cfg interface{}) Args {
 	flagSettings.BoolVar(&processedArgs.OauthAutoLogin, "auto-login", false, "oauth_auto_login is enabled in grafana config")
 	flagSettings.BoolVar(&processedArgs.OauthWaitForPasswordField, "wait-for-password-field", false, "oauth_auto_login is enabled in grafana config")
 	flagSettings.StringVar(&processedArgs.OauthWaitForPasswordFieldIgnoreClass, "wait-for-password-field-class", "", "oauth_auto_login is enabled in grafana config")
+	flagSettings.BoolVar(&processedArgs.OauthWaitForStaySignedInPrompt, "wait-for-stay-signed-in-prompt", false, "oauth_auto_login is enabled in grafana config")
 	flagSettings.StringVar(&processedArgs.UsernameField, "field-username", "username", "Fieldname for the username")
 	flagSettings.StringVar(&processedArgs.PasswordField, "field-password", "password", "Fieldname for the password")
 	flagSettings.StringVar(&processedArgs.Audience, "audience", "", "idtoken audience")
@@ -198,6 +200,9 @@ func main() {
 		cfg.GoAuth.AutoLogin = args.OauthAutoLogin
 		cfg.GoAuth.UsernameField = args.UsernameField
 		cfg.GoAuth.PasswordField = args.PasswordField
+		cfg.GoAuth.WaitForPasswordField = args.OauthWaitForPasswordField
+		cfg.GoAuth.WaitForPasswordFieldIgnoreClass = args.OauthWaitForPasswordFieldIgnoreClass
+		cfg.GoAuth.WaitForStaySignedInPrompt = args.OauthWaitForStaySignedInPrompt
 
 		cfg.IDToken.Audience = args.Audience
 		cfg.IDToken.KeyFile = args.KeyFile

--- a/pkg/kiosk/config.go
+++ b/pkg/kiosk/config.go
@@ -38,6 +38,7 @@ type GoAuth struct {
 	PasswordField                   string `yaml:"fieldname-password" env:"KIOSK_GOAUTH_FIELD_PASSWORD" env-description:"Password html input name value"`
 	WaitForPasswordField            bool   `yaml:"wait-for-password-field" env:"KIOSK_GOAUTH_WAIT_FOR_PASSWORD_FIELD" env-description:"Indicate that it's necessary to wait for the password field"`
 	WaitForPasswordFieldIgnoreClass string `yaml:"wait-for-password-field-class" env:"KIOSK_GOAUTH_WAIT_FOR_PASSWORD_FIELD_CLASS" env-description:"Ignore this password field when waiting for it being visible"`
+	WaitForStaySignedInPrompt       bool   `yaml:"wait-for-stay-signed-in-prompt" env:"KIOSK_GOAUTH_WAIT_FOR_STAY_SIGNED_IN_PROMPT" env-description:"Indicate that it's necessary to wait for the stay signed in prompt, and will then click yes"`
 }
 
 // IDToken token based login

--- a/pkg/kiosk/grafana_genericoauth_login.go
+++ b/pkg/kiosk/grafana_genericoauth_login.go
@@ -88,6 +88,14 @@ func GrafanaKioskGenericOauth(cfg *Config, messages chan string) {
 			panic(err)
 		}
 	}
+	if cfg.GoAuth.WaitForStaySignedInPrompt {
+		if err := chromedp.Run(taskCtx,
+			chromedp.WaitVisible(`//input[@type="submit" and @value="Yes"]`, chromedp.BySearch),
+			chromedp.Click(`//input[@type="submit" and @value="Yes"]`, chromedp.BySearch),
+		); err != nil {
+			panic(err)
+		}
+	}
 	// blocking wait
 	for {
 		messageFromChrome := <-messages


### PR DESCRIPTION
This PR will add a bool to the config, if set to true, the oauth sign in flow will wait for a submit input with the value of "Yes" and then click it. 

This can be relevant if using Microsoft auth, which could cause the screen to be stuck on a "Stay signed in" page. 