### PR TITLE
Fix Environment Variables Not Working with Command-Line Arguments

### DIFF
--- a/pkg/cmd/grafana-kiosk/main_test.go
+++ b/pkg/cmd/grafana-kiosk/main_test.go
@@ -54,14 +54,14 @@ func TestMain(t *testing.T) {
 				defer func() { os.Args = oldArgs }()
 				os.Args = []string{"grafana-kiosk", ""}
 				// starts out default true
-				result := ProcessArgs(cfg)
+				result, _ := ProcessArgs(cfg)
 				So(result.AutoFit, ShouldBeTrue)
 				// flag to set it false
 				os.Args = []string{
 					"grafana-kiosk",
 					"--autofit=false",
 				}
-				result = ProcessArgs(cfg)
+				result, _ = ProcessArgs(cfg)
 				So(result.AutoFit, ShouldBeFalse)
 			})
 
@@ -86,7 +86,7 @@ func TestMain(t *testing.T) {
 			oldArgs := os.Args
 			defer func() { os.Args = oldArgs }()
 			os.Args = []string{"grafana-kiosk", ""}
-			result := ProcessArgs(cfg)
+			result, _ := ProcessArgs(cfg)
 			So(result.LoginMethod, ShouldEqual, "anon")
 			So(result.URL, ShouldEqual, "https://play.grafana.org")
 			So(result.AutoFit, ShouldBeTrue)
@@ -95,7 +95,7 @@ func TestMain(t *testing.T) {
 			oldArgs := os.Args
 			defer func() { os.Args = oldArgs }()
 			os.Args = []string{"grafana-kiosk", "-login-method", "local"}
-			result := ProcessArgs(cfg)
+			result, _ := ProcessArgs(cfg)
 			So(result.LoginMethod, ShouldEqual, "local")
 			So(result.URL, ShouldEqual, "https://play.grafana.org")
 			So(result.AutoFit, ShouldBeTrue)


### PR DESCRIPTION
Environment variables are overridden by command-line arguments defaults due to them having a default value and applying after the environment variables are assigned.

This fix makes sure that only command-line arguments that are set override environment variables, leaving the value that was previously set by the environment untouched if it was not.

Closes #198