### PR TITLE
fix: inject CSS to hide AWS cookie banner during navigation

### DIFF
--- a/pkg/kiosk/apikey_login.go
+++ b/pkg/kiosk/apikey_login.go
@@ -97,6 +97,31 @@ func GrafanaKioskAPIKey(cfg *Config, messages chan string) {
 		taskCtx,
 		fetch.Enable().WithPatterns([]*fetch.RequestPattern{{URLPattern: u.Scheme + "://" + u.Host + "/*"}}),
 		chromedp.Navigate(generatedURL),
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			log.Println("Injecting CSS to hide AWS cookie banner...")
+			chromedp.Run(ctx,
+				chromedp.Evaluate(`
+					(function() {
+						var style = document.createElement('style');
+						style.id = 'grafana-kiosk-hide-cookie-banner';
+						style.textContent = [
+							'[id^="awsccc"]',
+							'[class^="awsccc"]',
+							'[class*="awsccc"]',
+							'[data-id^="awsccc"]',
+							'#onetrust-consent-sdk',
+							'[class*="cookie-consent"]',
+							'[class*="cookie-banner"]',
+							'[id*="cookie-consent"]',
+							'[id*="cookie-banner"]'
+						].join(', ') + ' { display: none !important; visibility: hidden !important; pointer-events: none !important; }';
+						document.head.appendChild(style);
+						return 'CSS injected';
+					})()
+				`, nil),
+			)
+			return nil
+		}),
 		chromedp.ActionFunc(func(context.Context) error {
 			log.Printf("Sleeping %d MS before continuing", cfg.General.PageLoadDelayMS)
 			time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)


### PR DESCRIPTION
Small fix to not show the Cookie banner in case of api key login method is used.
Tested this and seems to work well.

Closes #129