### PR TITLE
chore: add coverage badges to README, disable octocov PR comment

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -4,10 +4,7 @@ coverage:
   paths:
     - coverage.out
 comment:
-  enable: true
-  hideFooterLink: false
-  updatePrevious: true
-  message: "Full coverage report available in the **coverage-report** artifact (Actions → Artifacts)."
+  enable: false
 codeToTestRatio:
   badge:
     path: docs/ratio.svg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to
 - Add octocov-action to CI for test coverage reporting on PRs
 - Add `pull_request` trigger to Build CI workflow
 - Save coverage report as CI artifact
+- Disable octocov PR comment, use PR body insertion only
+- Add octocov coverage badges to README
 
 ## 1.0.11
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fgrafana%2Fgrafana-kiosk%2Fbadge%3Fref%3Dmain&style=flat)](https://actions-badge.atrox.dev/grafana/grafana-kiosk/goto?ref=main)
 [![Go Report Card](https://goreportcard.com/badge/github.com/grafana/grafana-kiosk)](https://goreportcard.com/report/github.com/grafana/grafana-kiosk)
+![coverage](docs/coverage.svg) ![coverage](docs/ratio.svg) ![coverage](docs/time.svg)
 
 A very useful feature of Grafana is the ability to display dashboards and playlists on a large TV.
 


### PR DESCRIPTION
## Summary
- Add octocov-generated coverage, code-to-test ratio, and build time badges to README header
- Disable octocov PR comment — coverage report now appears in PR body only

## Test plan
- [ ] Verify badge images render correctly on GitHub
- [ ] Confirm octocov inserts coverage into PR body (not as comment)
<!-- octocov -->
## Code Metrics Report
| Coverage | Code to Test Ratio | Test Execution Time |
|---------:|-------------------:|--------------------:|
| 17.6%    | 1:0.5              | 3m21s               |



---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
