### PR TITLE
fix(ci): persist coverage badges, add actionlint, restrict permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,14 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write      # badge branch push, releases
+      pull-requests: write # octocov PR body insertion
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -52,6 +57,29 @@ jobs:
 
       - name: Report coverage
         uses: k1LoW/octocov-action@73d561f65d59e66899ed5c87e4621a913b5d5c20 # v1.5.0
+
+      - name: Push coverage badges
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: |
+          # Save generated badges before switching branches
+          mkdir -p /tmp/badges
+          cp docs/coverage.svg docs/ratio.svg docs/time.svg /tmp/badges/
+          # Set up git for the push
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Create or switch to orphan badges branch
+          git checkout --orphan badges
+          git rm -rf .
+          # Restore badges
+          mkdir -p docs
+          cp /tmp/badges/*.svg docs/
+          git add docs/
+          git commit -m "Update coverage badges"
+          git push origin badges --force
+          # Return to original ref for subsequent steps
+          git checkout ${{ github.sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload coverage report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,13 @@ on:
 permissions: {}
 
 jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
+
   build:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,11 @@ jobs:
       - name: Get BRANCH, NAME, TAG
         id: branch_name
         run: |
-          echo "SOURCE_NAME=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-          echo "SOURCE_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
-          echo "SOURCE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          {
+            echo "SOURCE_NAME=${GITHUB_REF#refs/*/}"
+            echo "SOURCE_BRANCH=${GITHUB_REF#refs/heads/}"
+            echo "SOURCE_TAG=${GITHUB_REF#refs/tags/}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build with Mage
         uses: magefile/mage-action@a662bd8c29d8106879588cfff83b2faf6e6f59db # v4.0.0
@@ -119,22 +121,22 @@ jobs:
         env:
           SOURCE_TAG: ${{ steps.branch_name.outputs.SOURCE_TAG }}
         run: |
-          export RELEASE_TARGET_DIR=grafana-kiosk-$SOURCE_TAG
-          mkdir $RELEASE_TARGET_DIR
-          cp -p bin/darwin_amd64/grafana-kiosk $RELEASE_TARGET_DIR/grafana-kiosk.darwin.amd64
-          cp -p bin/darwin_arm64/grafana-kiosk $RELEASE_TARGET_DIR/grafana-kiosk.darwin.arm64
-          cp -p bin/linux_386/grafana-kiosk $RELEASE_TARGET_DIR/grafana-kiosk.linux.386
-          cp -p bin/linux_amd64/grafana-kiosk $RELEASE_TARGET_DIR/grafana-kiosk.linux.amd64
-          cp -p bin/linux_arm64/grafana-kiosk $RELEASE_TARGET_DIR/grafana-kiosk.linux.arm64
-          cp -p bin/linux_armv5/grafana-kiosk $RELEASE_TARGET_DIR/grafana-kiosk.linux.armv5
-          cp -p bin/linux_armv6/grafana-kiosk $RELEASE_TARGET_DIR/grafana-kiosk.linux.armv6
-          cp -p bin/linux_armv7/grafana-kiosk $RELEASE_TARGET_DIR/grafana-kiosk.linux.armv7
-          cp -p bin/windows_amd64/grafana-kiosk $RELEASE_TARGET_DIR/grafana-kiosk.windows.amd64.exe
-          zip -r grafana-kiosk-$SOURCE_TAG.zip $RELEASE_TARGET_DIR
-          tar cf grafana-kiosk-$SOURCE_TAG.tar $RELEASE_TARGET_DIR
-          gzip grafana-kiosk-$SOURCE_TAG.tar
-          mv grafana-kiosk-$SOURCE_TAG.tar.gz $RELEASE_TARGET_DIR
-          mv grafana-kiosk-$SOURCE_TAG.zip $RELEASE_TARGET_DIR
+          export RELEASE_TARGET_DIR="grafana-kiosk-${SOURCE_TAG}"
+          mkdir "$RELEASE_TARGET_DIR"
+          cp -p bin/darwin_amd64/grafana-kiosk "$RELEASE_TARGET_DIR/grafana-kiosk.darwin.amd64"
+          cp -p bin/darwin_arm64/grafana-kiosk "$RELEASE_TARGET_DIR/grafana-kiosk.darwin.arm64"
+          cp -p bin/linux_386/grafana-kiosk "$RELEASE_TARGET_DIR/grafana-kiosk.linux.386"
+          cp -p bin/linux_amd64/grafana-kiosk "$RELEASE_TARGET_DIR/grafana-kiosk.linux.amd64"
+          cp -p bin/linux_arm64/grafana-kiosk "$RELEASE_TARGET_DIR/grafana-kiosk.linux.arm64"
+          cp -p bin/linux_armv5/grafana-kiosk "$RELEASE_TARGET_DIR/grafana-kiosk.linux.armv5"
+          cp -p bin/linux_armv6/grafana-kiosk "$RELEASE_TARGET_DIR/grafana-kiosk.linux.armv6"
+          cp -p bin/linux_armv7/grafana-kiosk "$RELEASE_TARGET_DIR/grafana-kiosk.linux.armv7"
+          cp -p bin/windows_amd64/grafana-kiosk "$RELEASE_TARGET_DIR/grafana-kiosk.windows.amd64.exe"
+          zip -r "grafana-kiosk-${SOURCE_TAG}.zip" "$RELEASE_TARGET_DIR"
+          tar cf "grafana-kiosk-${SOURCE_TAG}.tar" "$RELEASE_TARGET_DIR"
+          gzip "grafana-kiosk-${SOURCE_TAG}.tar"
+          mv "grafana-kiosk-${SOURCE_TAG}.tar.gz" "$RELEASE_TARGET_DIR"
+          mv "grafana-kiosk-${SOURCE_TAG}.zip" "$RELEASE_TARGET_DIR"
 
       - name: Upload Release Artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,26 +67,31 @@ jobs:
       - name: Report coverage
         uses: k1LoW/octocov-action@73d561f65d59e66899ed5c87e4621a913b5d5c20 # v1.5.0
 
-      - name: Push coverage badges
+      - name: Push coverage badge endpoint
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         run: |
-          # Save generated badges before switching branches
+          # Extract coverage percentage
+          COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | tr -d '%')
+          # Pick color based on coverage
+          if (( $(echo "$COVERAGE >= 80" | bc -l) )); then COLOR="brightgreen"
+          elif (( $(echo "$COVERAGE >= 60" | bc -l) )); then COLOR="yellow"
+          else COLOR="red"; fi
+          # Build shields.io endpoint JSON
           mkdir -p /tmp/badges
-          cp docs/coverage.svg docs/ratio.svg docs/time.svg /tmp/badges/
-          # Set up git for the push
+          cat > /tmp/badges/coverage.json <<BADGE
+          {"schemaVersion":1,"label":"coverage","message":"${COVERAGE}%","color":"${COLOR}"}
+          BADGE
+          # Push to badges branch
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # Create or switch to orphan badges branch
           git checkout --orphan badges
           git rm -rf .
-          # Restore badges
-          mkdir -p docs
-          cp /tmp/badges/*.svg docs/
-          git add docs/
-          git commit -m "Update coverage badges"
+          mkdir -p badges
+          cp /tmp/badges/coverage.json badges/
+          git add badges/
+          git commit -m "Update coverage badge"
           git push origin badges --force
-          # Return to original ref for subsequent steps
-          git checkout ${{ github.sha }}
+          git checkout "${{ github.sha }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -3,8 +3,6 @@ coverage:
     path: docs/coverage.svg
   paths:
     - coverage.out
-comment:
-  enable: false
 codeToTestRatio:
   badge:
     path: docs/ratio.svg
@@ -18,6 +16,6 @@ testExecutionTime:
   badge:
     path: docs/time.svg
 body:
-  enable: true
+  if: is_pull_request
 summary:
   if: true

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,11 +1,7 @@
 coverage:
-  badge:
-    path: docs/coverage.svg
   paths:
     - coverage.out
 codeToTestRatio:
-  badge:
-    path: docs/ratio.svg
   code:
     - '**/*.go'
     - '!**/*_test.go'
@@ -13,8 +9,6 @@ codeToTestRatio:
     - '**/*_test.go'
 testExecutionTime:
   if: is_pull_request
-  badge:
-    path: docs/time.svg
 body:
   if: is_pull_request
 summary:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,6 +274,7 @@ zizmor). Current versions:
 | `actions/stale` | v10.2.0 |
 | `k1LoW/octocov-action` | v1.5.0 |
 | `google/osv-scanner-action` | v2.3.5 |
+| `rhysd/actionlint` | v1.7.12 |
 
 When updating actions, always pin to full commit SHA with a version comment:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -413,8 +413,9 @@ Pushing a `v*` tag triggers the CI workflow which:
 - **Never commit directly to `main`**. Always create a new branch for changes.
 - Use descriptive branch names (e.g., `feat/add-feature`, `fix/bug-description`).
 - When pushing new commits to a PR, always update the PR summary to reflect all
-  changes. Categorize by type with Bug fixes listed first (e.g., Bug fixes,
-  Dependencies, Tests, Documentation & tooling).
+  changes. Categorize by type using H3 headings (`### Category`) with Bug Fixes
+  listed first. Common categories: Bug Fixes, CI/CD, Dependencies, Tests,
+  Chores, Documentation.
 - **Do not commit automatically**. Only commit when explicitly asked.
 - **Do not push automatically**. Only push when explicitly asked.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to
 - Restrict CI workflow permissions: global `permissions: {}` with
   job-level `contents: write` and `pull-requests: write`
 - Add `actionlint` job to CI for GitHub Actions workflow linting
+- Fix shellcheck warnings in CI workflow: quote variables, group redirects
 
 ## 1.0.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to
 - Save coverage report as CI artifact
 - Disable octocov PR comment, use PR body insertion only
 - Add octocov coverage badges to README
+- Fix broken badge images: push SVGs to `badges` branch from CI,
+  reference via raw GitHub URLs
+- Restrict CI workflow permissions: global `permissions: {}` with
+  job-level `contents: write` and `pull-requests: write`
 
 ## 1.0.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to
   reference via raw GitHub URLs
 - Restrict CI workflow permissions: global `permissions: {}` with
   job-level `contents: write` and `pull-requests: write`
+- Add `actionlint` job to CI for GitHub Actions workflow linting
 
 ## 1.0.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,8 @@ and this project adheres to
 - Save coverage report as CI artifact
 - Disable octocov PR comment, use PR body insertion only
 - Add octocov coverage badges to README
-- Fix broken badge images: push SVGs to `badges` branch from CI,
-  reference via raw GitHub URLs
+- Fix broken badge images: push shields.io JSON endpoint to `badges`
+  branch from CI, use shields.io dynamic badge in README
 - Restrict CI workflow permissions: global `permissions: {}` with
   job-level `contents: write` and `pull-requests: write`
 - Add `actionlint` job to CI for GitHub Actions workflow linting

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fgrafana%2Fgrafana-kiosk%2Fbadge%3Fref%3Dmain&style=flat)](https://actions-badge.atrox.dev/grafana/grafana-kiosk/goto?ref=main)
 [![Go Report Card](https://goreportcard.com/badge/github.com/grafana/grafana-kiosk)](https://goreportcard.com/report/github.com/grafana/grafana-kiosk)
-![coverage](docs/coverage.svg) ![coverage](docs/ratio.svg) ![coverage](docs/time.svg)
+![coverage](https://raw.githubusercontent.com/grafana/grafana-kiosk/badges/docs/coverage.svg)
+![code to test ratio](https://raw.githubusercontent.com/grafana/grafana-kiosk/badges/docs/ratio.svg)
+![test time](https://raw.githubusercontent.com/grafana/grafana-kiosk/badges/docs/time.svg)
 
 A very useful feature of Grafana is the ability to display dashboards and playlists on a large TV.
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 [![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fgrafana%2Fgrafana-kiosk%2Fbadge%3Fref%3Dmain&style=flat)](https://actions-badge.atrox.dev/grafana/grafana-kiosk/goto?ref=main)
 [![Go Report Card](https://goreportcard.com/badge/github.com/grafana/grafana-kiosk)](https://goreportcard.com/report/github.com/grafana/grafana-kiosk)
-![coverage](https://raw.githubusercontent.com/grafana/grafana-kiosk/badges/docs/coverage.svg)
-![code to test ratio](https://raw.githubusercontent.com/grafana/grafana-kiosk/badges/docs/ratio.svg)
-![test time](https://raw.githubusercontent.com/grafana/grafana-kiosk/badges/docs/time.svg)
+![coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/grafana/grafana-kiosk/badges/badges/coverage.json)
 
 A very useful feature of Grafana is the ability to display dashboards and playlists on a large TV.
 

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -60,6 +60,7 @@
     "Ronan",
     "scrollbars",
     "securego",
+    "shellcheck",
     "softprops",
     "Stäheli",
     "stdlib",

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -56,6 +56,7 @@
     "Println",
     "Ramberg",
     "raspberrypi",
+    "rhysd",
     "Ronan",
     "scrollbars",
     "securego",


### PR DESCRIPTION
## Summary

### Bug Fixes
- Fix broken README badge images: CI extracts coverage % and pushes a
  shields.io JSON endpoint to an orphan `badges` branch on main merges
- Fix shellcheck warnings in CI: quote all shell variables, use grouped redirects

### CI/CD
- Restrict CI workflow permissions: global `permissions: {}` with job-level
  grants for `contents: write` and `pull-requests: write`
- Add `actionlint` job (rhysd/actionlint v1.7.12) for GitHub Actions workflow linting
- README uses shields.io dynamic badge backed by JSON endpoint on `badges` branch

### Chores
- Clean up octocov config: remove comment section, remove SVG badge paths,
  restrict body insertion to PRs only

### Documentation
- Clarify PR summary categorization rule in AGENTS.md: use H3 headings,
  Bug Fixes first, with common category names

## Test plan
- [ ] Merge to main triggers badge JSON push to `badges` branch
- [ ] shields.io badge renders correctly in README after first main merge
- [ ] octocov PR body insertion still works with explicit permissions
- [ ] Release workflow still functions with `contents: write`
- [ ] actionlint job passes on CI
<!-- octocov -->
## Code Metrics Report
| Coverage | Code to Test Ratio | Test Execution Time |
|---------:|-------------------:|--------------------:|
| 17.6%    | 1:0.5              | 3m16s               |



---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
