### PR TITLE
fix: CLI flags now override config file values

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,8 +84,9 @@ There is no `.golangci.yml` config file. CI runs golangci-lint v2 and gosec
 with default settings.
 
 **IMPORTANT**: Always run `golangci-lint run --timeout 5m ./pkg/...` and
-`gosec ./...` before committing and fix any issues. CI will reject code
-with lint or security violations.
+`gosec ./...` before committing when `.go` files are modified or added.
+Fix any issues before creating the commit. CI will reject code with lint
+or security violations.
 
 **IMPORTANT**: If `go.mod` or `go.sum` changes, always run `mage -v` to
 verify the project builds successfully before committing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -413,10 +413,12 @@ Pushing a `v*` tag triggers the CI workflow which:
 
 - **Never commit directly to `main`**. Always create a new branch for changes.
 - Use descriptive branch names (e.g., `feat/add-feature`, `fix/bug-description`).
-- When pushing new commits to a PR, always update the PR summary to reflect all
-  changes. Categorize by type using H3 headings (`### Category`) with Bug Fixes
+- Use categorized PR summaries both when creating and when updating PRs.
+  Categorize by type using H3 headings (`### Category`) with Bug Fixes
   listed first. Common categories: Bug Fixes, CI/CD, Dependencies, Tests,
   Chores, Documentation.
+- When pushing new commits to a PR, always update the PR summary to reflect all
+  changes.
 - **Do not commit automatically**. Only commit when explicitly asked.
 - **Do not push automatically**. Only push when explicitly asked.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- Fix CLI flags not overriding config file values when using `-c`
+  (fixes #210)
 - Update Go module dependencies: chromedp/cdproto, magefile/mage v1.17.1,
   google.golang.org/api v0.275.0, golang.org/x/{crypto,net,sys,text},
   google.golang.org/grpc v1.80.0, go.opentelemetry.io/otel v1.43.0,

--- a/pkg/cmd/grafana-kiosk/main.go
+++ b/pkg/cmd/grafana-kiosk/main.go
@@ -200,48 +200,49 @@ func main() {
 		if err := cleanenv.ReadEnv(&cfg); err != nil {
 			log.Println("Error reading config from environment", err)
 		}
-
-		update := map[string]func(){
-			"URL":                       func() { cfg.Target.URL = args.URL },
-			"login-method":              func() { cfg.Target.LoginMethod = args.LoginMethod },
-			"username":                  func() { cfg.Target.Username = args.Username },
-			"password":                  func() { cfg.Target.Password = args.Password },
-			"ignore-certificate-errors": func() { cfg.Target.IgnoreCertificateErrors = args.IgnoreCertificateErrors },
-			"playlists":                 func() { cfg.Target.IsPlayList = args.IsPlayList },
-			"use-mfa":                   func() { cfg.Target.UseMFA = args.UseMFA },
-			//
-			"autofit":            func() { cfg.General.AutoFit = args.AutoFit },
-			"lxde":               func() { cfg.General.LXDEEnabled = args.LXDEEnabled },
-			"lxde-home":          func() { cfg.General.LXDEHome = args.LXDEHome },
-			"kiosk-mode":         func() { cfg.General.Mode = args.Mode },
-			"window-position":    func() { cfg.General.WindowPosition = args.WindowPosition },
-			"window-size":        func() { cfg.General.WindowSize = args.WindowSize },
-			"scale-factor":       func() { cfg.General.ScaleFactor = args.ScaleFactor },
-			"page-load-delay-ms": func() { cfg.General.PageLoadDelayMS = args.PageLoadDelayMS },
-			"hide-links":         func() { cfg.General.HideLinks = args.HideLinks },
-			"hide-time-picker":   func() { cfg.General.HideTimePicker = args.HideTimePicker },
-			"hide-variables":     func() { cfg.General.HideVariables = args.HideVariables },
-			"incognito":          func() { cfg.General.Incognito = args.Incognito },
-			//
-			"auto-login":                     func() { cfg.GoAuth.AutoLogin = args.OauthAutoLogin },
-			"field-username":                 func() { cfg.GoAuth.UsernameField = args.UsernameField },
-			"field-password":                 func() { cfg.GoAuth.PasswordField = args.PasswordField },
-			"wait-for-password-field":        func() { cfg.GoAuth.WaitForPasswordField = args.OauthWaitForPasswordField },
-			"wait-for-password-field-class":  func() { cfg.GoAuth.WaitForPasswordFieldIgnoreClass = args.OauthWaitForPasswordFieldIgnoreClass },
-			"wait-for-stay-signed-in-prompt": func() { cfg.GoAuth.WaitForStaySignedInPrompt = args.OauthWaitForStaySignedInPrompt },
-
-			"audience": func() { cfg.IDToken.Audience = args.Audience },
-			"keyfile":  func() { cfg.IDToken.KeyFile = args.KeyFile },
-
-			"apikey": func() { cfg.APIKey.APIKey = args.APIKey },
-		}
-
-		fs.Visit(func(f *flag.Flag) {
-			if do, ok := update[f.Name]; ok {
-				do()
-			}
-		})
 	}
+
+	// apply CLI flag overrides (flags take precedence over config file and environment)
+	update := map[string]func(){
+		"URL":                       func() { cfg.Target.URL = args.URL },
+		"login-method":              func() { cfg.Target.LoginMethod = args.LoginMethod },
+		"username":                  func() { cfg.Target.Username = args.Username },
+		"password":                  func() { cfg.Target.Password = args.Password },
+		"ignore-certificate-errors": func() { cfg.Target.IgnoreCertificateErrors = args.IgnoreCertificateErrors },
+		"playlists":                 func() { cfg.Target.IsPlayList = args.IsPlayList },
+		"use-mfa":                   func() { cfg.Target.UseMFA = args.UseMFA },
+		//
+		"autofit":            func() { cfg.General.AutoFit = args.AutoFit },
+		"lxde":               func() { cfg.General.LXDEEnabled = args.LXDEEnabled },
+		"lxde-home":          func() { cfg.General.LXDEHome = args.LXDEHome },
+		"kiosk-mode":         func() { cfg.General.Mode = args.Mode },
+		"window-position":    func() { cfg.General.WindowPosition = args.WindowPosition },
+		"window-size":        func() { cfg.General.WindowSize = args.WindowSize },
+		"scale-factor":       func() { cfg.General.ScaleFactor = args.ScaleFactor },
+		"page-load-delay-ms": func() { cfg.General.PageLoadDelayMS = args.PageLoadDelayMS },
+		"hide-links":         func() { cfg.General.HideLinks = args.HideLinks },
+		"hide-time-picker":   func() { cfg.General.HideTimePicker = args.HideTimePicker },
+		"hide-variables":     func() { cfg.General.HideVariables = args.HideVariables },
+		"incognito":          func() { cfg.General.Incognito = args.Incognito },
+		//
+		"auto-login":                     func() { cfg.GoAuth.AutoLogin = args.OauthAutoLogin },
+		"field-username":                 func() { cfg.GoAuth.UsernameField = args.UsernameField },
+		"field-password":                 func() { cfg.GoAuth.PasswordField = args.PasswordField },
+		"wait-for-password-field":        func() { cfg.GoAuth.WaitForPasswordField = args.OauthWaitForPasswordField },
+		"wait-for-password-field-class":  func() { cfg.GoAuth.WaitForPasswordFieldIgnoreClass = args.OauthWaitForPasswordFieldIgnoreClass },
+		"wait-for-stay-signed-in-prompt": func() { cfg.GoAuth.WaitForStaySignedInPrompt = args.OauthWaitForStaySignedInPrompt },
+
+		"audience": func() { cfg.IDToken.Audience = args.Audience },
+		"keyfile":  func() { cfg.IDToken.KeyFile = args.KeyFile },
+
+		"apikey": func() { cfg.APIKey.APIKey = args.APIKey },
+	}
+
+	fs.Visit(func(f *flag.Flag) {
+		if do, ok := update[f.Name]; ok {
+			do()
+		}
+	})
 
 	// make sure the url has content
 	if cfg.Target.URL == "" {

--- a/pkg/cmd/grafana-kiosk/main.go
+++ b/pkg/cmd/grafana-kiosk/main.go
@@ -115,6 +115,67 @@ func ProcessArgs(cfg interface{}) (Args, *flag.FlagSet) {
 	return processedArgs, flagSettings
 }
 
+// loadConfig reads configuration from a file or environment, then applies
+// CLI flag overrides. Flags always take precedence.
+func loadConfig(args Args, fs *flag.FlagSet, cfg *kiosk.Config) error {
+	if args.ConfigPath != "" {
+		// read configuration from the file and then override with environment variables
+		if err := cleanenv.ReadConfig(args.ConfigPath, cfg); err != nil {
+			return fmt.Errorf("error reading config file: %w", err)
+		}
+		log.Println("Using config from", args.ConfigPath)
+	} else {
+		log.Println("No config specified, using environment and args")
+		if err := cleanenv.ReadEnv(cfg); err != nil {
+			log.Println("Error reading config from environment", err)
+		}
+	}
+
+	// apply CLI flag overrides (flags take precedence over config file and environment)
+	update := map[string]func(){
+		"URL":                       func() { cfg.Target.URL = args.URL },
+		"login-method":              func() { cfg.Target.LoginMethod = args.LoginMethod },
+		"username":                  func() { cfg.Target.Username = args.Username },
+		"password":                  func() { cfg.Target.Password = args.Password },
+		"ignore-certificate-errors": func() { cfg.Target.IgnoreCertificateErrors = args.IgnoreCertificateErrors },
+		"playlists":                 func() { cfg.Target.IsPlayList = args.IsPlayList },
+		"use-mfa":                   func() { cfg.Target.UseMFA = args.UseMFA },
+		//
+		"autofit":            func() { cfg.General.AutoFit = args.AutoFit },
+		"lxde":               func() { cfg.General.LXDEEnabled = args.LXDEEnabled },
+		"lxde-home":          func() { cfg.General.LXDEHome = args.LXDEHome },
+		"kiosk-mode":         func() { cfg.General.Mode = args.Mode },
+		"window-position":    func() { cfg.General.WindowPosition = args.WindowPosition },
+		"window-size":        func() { cfg.General.WindowSize = args.WindowSize },
+		"scale-factor":       func() { cfg.General.ScaleFactor = args.ScaleFactor },
+		"page-load-delay-ms": func() { cfg.General.PageLoadDelayMS = args.PageLoadDelayMS },
+		"hide-links":         func() { cfg.General.HideLinks = args.HideLinks },
+		"hide-time-picker":   func() { cfg.General.HideTimePicker = args.HideTimePicker },
+		"hide-variables":     func() { cfg.General.HideVariables = args.HideVariables },
+		"incognito":          func() { cfg.General.Incognito = args.Incognito },
+		//
+		"auto-login":                     func() { cfg.GoAuth.AutoLogin = args.OauthAutoLogin },
+		"field-username":                 func() { cfg.GoAuth.UsernameField = args.UsernameField },
+		"field-password":                 func() { cfg.GoAuth.PasswordField = args.PasswordField },
+		"wait-for-password-field":        func() { cfg.GoAuth.WaitForPasswordField = args.OauthWaitForPasswordField },
+		"wait-for-password-field-class":  func() { cfg.GoAuth.WaitForPasswordFieldIgnoreClass = args.OauthWaitForPasswordFieldIgnoreClass },
+		"wait-for-stay-signed-in-prompt": func() { cfg.GoAuth.WaitForStaySignedInPrompt = args.OauthWaitForStaySignedInPrompt },
+
+		"audience": func() { cfg.IDToken.Audience = args.Audience },
+		"keyfile":  func() { cfg.IDToken.KeyFile = args.KeyFile },
+
+		"apikey": func() { cfg.APIKey.APIKey = args.APIKey },
+	}
+
+	fs.Visit(func(f *flag.Flag) {
+		if do, ok := update[f.Name]; ok {
+			do()
+		}
+	})
+
+	return nil
+}
+
 func setEnvironment() {
 	// for linux/X display must be set
 	var displayEnv = os.Getenv("DISPLAY")
@@ -185,64 +246,10 @@ func main() {
 		os.Exit(-1)
 	}
 
-	// check if config specified
-	if args.ConfigPath != "" {
-		// read configuration from the file and then override with environment variables
-		if err := cleanenv.ReadConfig(args.ConfigPath, &cfg); err != nil {
-			log.Println("Error reading config file", err)
-			os.Exit(-1)
-		} else {
-			log.Println("Using config from", args.ConfigPath)
-		}
-	} else {
-		log.Println("No config specified, using environment and args")
-		// no config, use environment and args
-		if err := cleanenv.ReadEnv(&cfg); err != nil {
-			log.Println("Error reading config from environment", err)
-		}
+	if err := loadConfig(args, fs, &cfg); err != nil {
+		log.Println(err)
+		os.Exit(-1)
 	}
-
-	// apply CLI flag overrides (flags take precedence over config file and environment)
-	update := map[string]func(){
-		"URL":                       func() { cfg.Target.URL = args.URL },
-		"login-method":              func() { cfg.Target.LoginMethod = args.LoginMethod },
-		"username":                  func() { cfg.Target.Username = args.Username },
-		"password":                  func() { cfg.Target.Password = args.Password },
-		"ignore-certificate-errors": func() { cfg.Target.IgnoreCertificateErrors = args.IgnoreCertificateErrors },
-		"playlists":                 func() { cfg.Target.IsPlayList = args.IsPlayList },
-		"use-mfa":                   func() { cfg.Target.UseMFA = args.UseMFA },
-		//
-		"autofit":            func() { cfg.General.AutoFit = args.AutoFit },
-		"lxde":               func() { cfg.General.LXDEEnabled = args.LXDEEnabled },
-		"lxde-home":          func() { cfg.General.LXDEHome = args.LXDEHome },
-		"kiosk-mode":         func() { cfg.General.Mode = args.Mode },
-		"window-position":    func() { cfg.General.WindowPosition = args.WindowPosition },
-		"window-size":        func() { cfg.General.WindowSize = args.WindowSize },
-		"scale-factor":       func() { cfg.General.ScaleFactor = args.ScaleFactor },
-		"page-load-delay-ms": func() { cfg.General.PageLoadDelayMS = args.PageLoadDelayMS },
-		"hide-links":         func() { cfg.General.HideLinks = args.HideLinks },
-		"hide-time-picker":   func() { cfg.General.HideTimePicker = args.HideTimePicker },
-		"hide-variables":     func() { cfg.General.HideVariables = args.HideVariables },
-		"incognito":          func() { cfg.General.Incognito = args.Incognito },
-		//
-		"auto-login":                     func() { cfg.GoAuth.AutoLogin = args.OauthAutoLogin },
-		"field-username":                 func() { cfg.GoAuth.UsernameField = args.UsernameField },
-		"field-password":                 func() { cfg.GoAuth.PasswordField = args.PasswordField },
-		"wait-for-password-field":        func() { cfg.GoAuth.WaitForPasswordField = args.OauthWaitForPasswordField },
-		"wait-for-password-field-class":  func() { cfg.GoAuth.WaitForPasswordFieldIgnoreClass = args.OauthWaitForPasswordFieldIgnoreClass },
-		"wait-for-stay-signed-in-prompt": func() { cfg.GoAuth.WaitForStaySignedInPrompt = args.OauthWaitForStaySignedInPrompt },
-
-		"audience": func() { cfg.IDToken.Audience = args.Audience },
-		"keyfile":  func() { cfg.IDToken.KeyFile = args.KeyFile },
-
-		"apikey": func() { cfg.APIKey.APIKey = args.APIKey },
-	}
-
-	fs.Visit(func(f *flag.Flag) {
-		if do, ok := update[f.Name]; ok {
-			do()
-		}
-	})
 
 	// make sure the url has content
 	if cfg.Target.URL == "" {

--- a/pkg/cmd/grafana-kiosk/main_test.go
+++ b/pkg/cmd/grafana-kiosk/main_test.go
@@ -56,10 +56,10 @@ general:
 `
 		tmpFile, err := os.CreateTemp("", "kiosk-test-*.yaml")
 		So(err, ShouldBeNil)
-		defer os.Remove(tmpFile.Name())
+		defer func() { _ = os.Remove(tmpFile.Name()) }()
 		_, err = tmpFile.WriteString(configContent)
 		So(err, ShouldBeNil)
-		tmpFile.Close()
+		_ = tmpFile.Close()
 
 		Convey("CLI flag should override config file value", func() {
 			oldArgs := os.Args

--- a/pkg/cmd/grafana-kiosk/main_test.go
+++ b/pkg/cmd/grafana-kiosk/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"log"
 	"os"
 	"testing"
@@ -40,6 +41,83 @@ func TestSanitize(t *testing.T) {
 }
 
 // TestKiosk checks kiosk command.
+func TestCLIFlagsOverrideConfigFile(t *testing.T) {
+	Convey("Given a config file with specific values", t, func() {
+		// create a temp config file with ignore-certificate-errors: false
+		configContent := `
+target:
+  URL: https://example.com
+  login-method: anon
+  ignore-certificate-errors: false
+general:
+  kiosk-mode: full
+  autofit: true
+  incognito: true
+`
+		tmpFile, err := os.CreateTemp("", "kiosk-test-*.yaml")
+		So(err, ShouldBeNil)
+		defer os.Remove(tmpFile.Name())
+		_, err = tmpFile.WriteString(configContent)
+		So(err, ShouldBeNil)
+		tmpFile.Close()
+
+		Convey("CLI flag should override config file value", func() {
+			oldArgs := os.Args
+			defer func() { os.Args = oldArgs }()
+			os.Args = []string{
+				"grafana-kiosk",
+				"-c", tmpFile.Name(),
+				"-ignore-certificate-errors",
+			}
+			var cfg kiosk.Config
+			args, fs := ProcessArgs(&cfg)
+			// load config file
+			So(args.ConfigPath, ShouldNotBeEmpty)
+			err := cleanenv.ReadConfig(args.ConfigPath, &cfg)
+			So(err, ShouldBeNil)
+			// config file has it false
+			So(cfg.Target.IgnoreCertificateErrors, ShouldBeFalse)
+
+			// apply CLI overrides (the fixed behavior)
+			update := map[string]func(){
+				"ignore-certificate-errors": func() { cfg.Target.IgnoreCertificateErrors = args.IgnoreCertificateErrors },
+				"incognito":                 func() { cfg.General.Incognito = args.Incognito },
+			}
+			fs.Visit(func(f *flag.Flag) {
+				if do, ok := update[f.Name]; ok {
+					do()
+				}
+			})
+			// CLI flag should win
+			So(cfg.Target.IgnoreCertificateErrors, ShouldBeTrue)
+		})
+
+		Convey("Config file value should be used when no CLI flag is passed", func() {
+			oldArgs := os.Args
+			defer func() { os.Args = oldArgs }()
+			os.Args = []string{
+				"grafana-kiosk",
+				"-c", tmpFile.Name(),
+			}
+			var cfg kiosk.Config
+			args, fs := ProcessArgs(&cfg)
+			err := cleanenv.ReadConfig(args.ConfigPath, &cfg)
+			So(err, ShouldBeNil)
+
+			update := map[string]func(){
+				"ignore-certificate-errors": func() { cfg.Target.IgnoreCertificateErrors = args.IgnoreCertificateErrors },
+			}
+			fs.Visit(func(f *flag.Flag) {
+				if do, ok := update[f.Name]; ok {
+					do()
+				}
+			})
+			// no CLI flag passed, config value (false) should remain
+			So(cfg.Target.IgnoreCertificateErrors, ShouldBeFalse)
+		})
+	})
+}
+
 func TestMain(t *testing.T) {
 	Convey("Given Default Configuration", t, func() {
 		cfg := kiosk.Config{

--- a/pkg/cmd/grafana-kiosk/main_test.go
+++ b/pkg/cmd/grafana-kiosk/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"log"
 	"os"
 	"testing"
@@ -43,7 +42,6 @@ func TestSanitize(t *testing.T) {
 // TestKiosk checks kiosk command.
 func TestCLIFlagsOverrideConfigFile(t *testing.T) {
 	Convey("Given a config file with specific values", t, func() {
-		// create a temp config file with ignore-certificate-errors: false
 		configContent := `
 target:
   URL: https://example.com
@@ -53,6 +51,8 @@ general:
   kiosk-mode: full
   autofit: true
   incognito: true
+  window-position: "0,0"
+  scale-factor: "1.0"
 `
 		tmpFile, err := os.CreateTemp("", "kiosk-test-*.yaml")
 		So(err, ShouldBeNil)
@@ -71,24 +71,8 @@ general:
 			}
 			var cfg kiosk.Config
 			args, fs := ProcessArgs(&cfg)
-			// load config file
-			So(args.ConfigPath, ShouldNotBeEmpty)
-			err := cleanenv.ReadConfig(args.ConfigPath, &cfg)
+			err := loadConfig(args, fs, &cfg)
 			So(err, ShouldBeNil)
-			// config file has it false
-			So(cfg.Target.IgnoreCertificateErrors, ShouldBeFalse)
-
-			// apply CLI overrides (the fixed behavior)
-			update := map[string]func(){
-				"ignore-certificate-errors": func() { cfg.Target.IgnoreCertificateErrors = args.IgnoreCertificateErrors },
-				"incognito":                 func() { cfg.General.Incognito = args.Incognito },
-			}
-			fs.Visit(func(f *flag.Flag) {
-				if do, ok := update[f.Name]; ok {
-					do()
-				}
-			})
-			// CLI flag should win
 			So(cfg.Target.IgnoreCertificateErrors, ShouldBeTrue)
 		})
 
@@ -101,19 +85,44 @@ general:
 			}
 			var cfg kiosk.Config
 			args, fs := ProcessArgs(&cfg)
-			err := cleanenv.ReadConfig(args.ConfigPath, &cfg)
+			err := loadConfig(args, fs, &cfg)
 			So(err, ShouldBeNil)
-
-			update := map[string]func(){
-				"ignore-certificate-errors": func() { cfg.Target.IgnoreCertificateErrors = args.IgnoreCertificateErrors },
-			}
-			fs.Visit(func(f *flag.Flag) {
-				if do, ok := update[f.Name]; ok {
-					do()
-				}
-			})
-			// no CLI flag passed, config value (false) should remain
 			So(cfg.Target.IgnoreCertificateErrors, ShouldBeFalse)
+		})
+
+		Convey("Multiple CLI flags should override respective config values", func() {
+			oldArgs := os.Args
+			defer func() { os.Args = oldArgs }()
+			os.Args = []string{
+				"grafana-kiosk",
+				"-c", tmpFile.Name(),
+				"-ignore-certificate-errors",
+				"-kiosk-mode", "tv",
+				"-incognito=false",
+			}
+			var cfg kiosk.Config
+			args, fs := ProcessArgs(&cfg)
+			err := loadConfig(args, fs, &cfg)
+			So(err, ShouldBeNil)
+			So(cfg.Target.IgnoreCertificateErrors, ShouldBeTrue)
+			So(cfg.General.Mode, ShouldEqual, "tv")
+			So(cfg.General.Incognito, ShouldBeFalse)
+			// non-overridden values preserved from config file
+			So(cfg.Target.URL, ShouldEqual, "https://example.com")
+			So(cfg.General.AutoFit, ShouldBeTrue)
+		})
+
+		Convey("Invalid config path should return error", func() {
+			oldArgs := os.Args
+			defer func() { os.Args = oldArgs }()
+			os.Args = []string{
+				"grafana-kiosk",
+				"-c", "/nonexistent/config.yaml",
+			}
+			var cfg kiosk.Config
+			args, fs := ProcessArgs(&cfg)
+			err := loadConfig(args, fs, &cfg)
+			So(err, ShouldNotBeNil)
 		})
 	})
 }


### PR DESCRIPTION
## Summary

### Bug Fixes

- Fix CLI flags being silently ignored when a config file is provided via `-c`
- Move the flag-to-config override map and `fs.Visit()` call outside the if/else branch so flags always take precedence over config file and environment values

### Refactoring

- Extract config-loading logic into testable `loadConfig()` function

### Tests

- Add tests verifying CLI flags override config file values
- Add test for multiple simultaneous flag overrides with config value preservation
- Add test for invalid config path error handling

### Documentation

- Update AGENTS.md to require `golangci-lint` before committing `.go` changes
- Update AGENTS.md to require categorized PR summaries on create and update
- Add changelog entry

Fixes #210

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing + new test cases, 19 assertions)
- [x] `golangci-lint run --timeout 5m ./pkg/...` passes
- [ ] Manual: run with `-c config.yaml -ignore-certificate-errors` and verify the CLI flag overrides the config file value
- [ ] Manual: run with `-c config.yaml` (no extra flags) and verify config file values are used unchanged
<!-- octocov -->
## Code Metrics Report
| Coverage | Code to Test Ratio | Test Execution Time |
|---------:|-------------------:|--------------------:|
| 19.7%    | 1:0.5              | 3m21s               |


### Code coverage of files in pull request scope (29.6%)

|                                                                            Files                                                                            | Coverage |
|-------------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|
| [pkg/cmd/grafana-kiosk/main.go](https://github.com/grafana/grafana-kiosk/blob/03075368bd22e4005a2cc6e038527e424406e6a6/pkg%2Fcmd%2Fgrafana-kiosk%2Fmain.go) | 29.6%    |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
