### PR TITLE
fix: disable Chromium HTTPS-First Mode to allow HTTP URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- Fix HTTP URLs blocked by Chromium 130+ HTTPS-First Mode
+  (fixes #155)
 - Fix CLI flags not overriding config file values when using `-c`
   (fixes #210)
 - Update Go module dependencies: chromedp/cdproto, magefile/mage v1.17.1,

--- a/pkg/kiosk/utils.go
+++ b/pkg/kiosk/utils.go
@@ -69,6 +69,14 @@ func generateExecutorOptions(dir string, cfg *Config) []chromedp.ExecAllocatorOp
 	// --disable-gpu
 	//    Disables GPU hardware acceleration. If software renderer is not in place, then the GPU process won't launch.--disable-gpu
 
+	// Chromium 130+ enables HTTPS-First Mode by default, which blocks
+	// plain HTTP page loads with ERR_BLOCKED_BY_CLIENT. Disable it when
+	// the target URL uses HTTP.
+	disableFeatures := "Translate"
+	if strings.HasPrefix(cfg.Target.URL, "http://") {
+		disableFeatures += ",HttpsUpgrades"
+	}
+
 	execAllocatorOption := []chromedp.ExecAllocatorOption{
 		chromedp.NoFirstRun,
 		chromedp.NoDefaultBrowserCheck,
@@ -76,7 +84,7 @@ func generateExecutorOptions(dir string, cfg *Config) []chromedp.ExecAllocatorOp
 		chromedp.Flag("bwsi", true),
 		chromedp.Flag("check-for-update-interval", "31536000"),
 		chromedp.Flag("password-store", "basic"), // prevent key store popup
-		chromedp.Flag("disable-features", "Translate,HttpsUpgrades"),
+		chromedp.Flag("disable-features", disableFeatures),
 		chromedp.Flag("disable-notifications", true),
 		chromedp.Flag("disable-overlay-scrollbar", true),
 		chromedp.Flag("hide-scrollbars", true),

--- a/pkg/kiosk/utils.go
+++ b/pkg/kiosk/utils.go
@@ -76,7 +76,7 @@ func generateExecutorOptions(dir string, cfg *Config) []chromedp.ExecAllocatorOp
 		chromedp.Flag("bwsi", true),
 		chromedp.Flag("check-for-update-interval", "31536000"),
 		chromedp.Flag("password-store", "basic"), // prevent key store popup
-		chromedp.Flag("disable-features", "Translate"),
+		chromedp.Flag("disable-features", "Translate,HttpsUpgrades"),
 		chromedp.Flag("disable-notifications", true),
 		chromedp.Flag("disable-overlay-scrollbar", true),
 		chromedp.Flag("hide-scrollbars", true),

--- a/pkg/kiosk/utils_test.go
+++ b/pkg/kiosk/utils_test.go
@@ -118,7 +118,7 @@ func TestGenerateExecutorOptions(t *testing.T) {
 				So(flags["bwsi"], ShouldEqual, true)
 				So(flags["check-for-update-interval"], ShouldEqual, "31536000")
 				So(flags["password-store"], ShouldEqual, "basic")
-				So(flags["disable-features"], ShouldEqual, "Translate,HttpsUpgrades")
+				So(flags["disable-features"], ShouldEqual, "Translate")
 				So(flags["disable-notifications"], ShouldEqual, true)
 				So(flags["disable-overlay-scrollbar"], ShouldEqual, true)
 				So(flags["hide-scrollbars"], ShouldEqual, true)
@@ -451,6 +451,42 @@ func TestGenerateExecutorOptions(t *testing.T) {
 
 			Convey("Should set incognito to false", func() {
 				So(flags["incognito"], ShouldEqual, false)
+			})
+		})
+
+		Convey("When target URL uses HTTP", func() {
+			cfg := &Config{
+				BuildInfo: BuildInfo{Version: "v1.0.0"},
+				General: General{
+					WindowPosition: "0,0",
+				},
+				Target: Target{
+					URL: "http://grafana.local:3000/dashboard",
+				},
+			}
+			opts := generateExecutorOptions("/tmp/test", cfg)
+			flags := applyOptions(opts)
+
+			Convey("Should disable HttpsUpgrades feature", func() {
+				So(flags["disable-features"], ShouldEqual, "Translate,HttpsUpgrades")
+			})
+		})
+
+		Convey("When target URL uses HTTPS", func() {
+			cfg := &Config{
+				BuildInfo: BuildInfo{Version: "v1.0.0"},
+				General: General{
+					WindowPosition: "0,0",
+				},
+				Target: Target{
+					URL: "https://grafana.example.com/dashboard",
+				},
+			}
+			opts := generateExecutorOptions("/tmp/test", cfg)
+			flags := applyOptions(opts)
+
+			Convey("Should not disable HttpsUpgrades feature", func() {
+				So(flags["disable-features"], ShouldEqual, "Translate")
 			})
 		})
 	})

--- a/pkg/kiosk/utils_test.go
+++ b/pkg/kiosk/utils_test.go
@@ -118,7 +118,7 @@ func TestGenerateExecutorOptions(t *testing.T) {
 				So(flags["bwsi"], ShouldEqual, true)
 				So(flags["check-for-update-interval"], ShouldEqual, "31536000")
 				So(flags["password-store"], ShouldEqual, "basic")
-				So(flags["disable-features"], ShouldEqual, "Translate")
+				So(flags["disable-features"], ShouldEqual, "Translate,HttpsUpgrades")
 				So(flags["disable-notifications"], ShouldEqual, true)
 				So(flags["disable-overlay-scrollbar"], ShouldEqual, true)
 				So(flags["hide-scrollbars"], ShouldEqual, true)


### PR DESCRIPTION
## Summary

### Bug Fixes

- Disable Chromium's `HttpsUpgrades` feature flag when the target URL uses HTTP, preventing `ERR_BLOCKED_BY_CLIENT` errors on Chromium 130+
- Chromium 130+ enables HTTPS-First Mode by default, which attempts to upgrade HTTP to HTTPS and blocks the navigation if the upgrade fails
- Only applies the workaround for HTTP URLs — HTTPS targets keep Chromium's default behavior

### Tests

- Add tests verifying `HttpsUpgrades` is disabled for HTTP URLs and preserved for HTTPS URLs

Fixes #155

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run --timeout 5m ./pkg/...` — 0 issues
- [ ] Manual: run with an HTTP URL on Chromium 130+ and verify the page loads without `ERR_BLOCKED_BY_CLIENT`
- [ ] Manual: run with an HTTPS URL and verify normal behavior
<!-- octocov -->
## Code Metrics Report
| Coverage | Code to Test Ratio | Test Execution Time |
|---------:|-------------------:|--------------------:|
| 20.2%    | 1:0.6              | 3m1s                |


### Code coverage of files in pull request scope (100.0%)

|                                                                Files                                                                | Coverage |
|-------------------------------------------------------------------------------------------------------------------------------------|---------:|
| [pkg/kiosk/utils.go](https://github.com/grafana/grafana-kiosk/blob/8559380657766bcb941fae4876ed85f22841260e/pkg%2Fkiosk%2Futils.go) | 100.0%   |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
