### PR TITLE
fix: dispatch resize event after navigation for Grafana 12+ autofit

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,25 @@
+name: Markdown Lint
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**.md'
+      - '.markdownlint-cli2.yaml'
+  pull_request:
+    paths:
+      - '**.md'
+      - '.markdownlint-cli2.yaml'
+
+permissions: {}
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: DavidAnson/markdownlint-cli2-action@ce4853d43830c74c1753b39f3cf40f71c2031eb9 # v23.0.0
+        with:
+          config: .markdownlint-cli2.yaml

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -4,3 +4,5 @@ config:
     code_blocks: false
   no-duplicate-heading:
     siblings_only: true
+ignores:
+  - CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -417,9 +417,9 @@ Pushing a `v*` tag triggers the CI workflow which:
 - **Never commit directly to `main`**. Always create a new branch for changes.
 - Use descriptive branch names (e.g., `feat/add-feature`, `fix/bug-description`).
 - Use categorized PR summaries both when creating and when updating PRs.
-  Categorize by type using H3 headings (`### Category`) with Bug Fixes
-  listed first. Common categories: Bug Fixes, CI/CD, Dependencies, Tests,
-  Chores, Documentation.
+  Categorize by type using H3 headings (`### Category`) in the same order
+  as the changelog: Features, Bug Fixes, Tests, CI/CD, Dependencies,
+  Chores, Documentation. Omit empty categories.
 - When pushing new commits to a PR, always update the PR summary to reflect all
   changes.
 - **Do not commit automatically**. Only commit when explicitly asked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,6 +420,8 @@ Pushing a `v*` tag triggers the CI workflow which:
   Categorize by type using H3 headings (`### Category`) in the same order
   as the changelog: Features, Bug Fixes, Tests, CI/CD, Dependencies,
   Chores, Documentation. Omit empty categories.
+- PR summary lines may be up to 120 characters before wrapping. Do not
+  split lines shorter than 120 characters.
 - When pushing new commits to a PR, always update the PR summary to reflect all
   changes.
 - **Do not commit automatically**. Only commit when explicitly asked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,6 +257,7 @@ GitHub Actions workflows (`.github/workflows/`):
   golangci-lint → gosec → `mage -v build:ci` → coverage upload → release
   packaging on version tags (`v*`).
 - **`osv-scanner-pr.yml`**: Vulnerability scanning on PRs to `main`.
+- **`markdownlint.yml`**: Lint `.md` files on push to `main` and PRs (path-filtered).
 - **`stale.yml`**: Auto-closes stale issues/PRs after 90+60 days.
 
 All actions are pinned to commit SHAs with version comments (required by
@@ -276,6 +277,7 @@ zizmor). Current versions:
 | `k1LoW/octocov-action` | v1.5.0 |
 | `google/osv-scanner-action` | v2.3.5 |
 | `rhysd/actionlint` | v1.7.12 |
+| `DavidAnson/markdownlint-cli2-action` | v23.0.0 |
 
 When updating actions, always pin to full commit SHA with a version comment:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -324,6 +324,10 @@ before pushing.
 Categorize entries under H3 headings in this order: Features, Bug Fixes,
 Tests, CI/CD, Dependencies, Chores. Omit empty categories.
 
+Changelog lines may be up to 120 characters before wrapping, matching
+the markdownlint `line-length` config. Do not wrap lines shorter than
+120 characters.
+
 ## Release Process
 
 This project uses [semantic versioning](https://semver.org/) with tags in the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -321,6 +321,9 @@ corresponding entry in the changelog under the current unreleased version
 section. Add entries as part of the same commit or as a follow-up commit
 before pushing.
 
+Categorize entries under H3 headings in this order: Features, Bug Fixes,
+Tests, CI/CD, Dependencies, Chores. Omit empty categories.
+
 ## Release Process
 
 This project uses [semantic versioning](https://semver.org/) with tags in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,17 +17,16 @@ and this project adheres to
 ### Bug Fixes
 
 - Fix Grafana 12+ scenes viewport changes causing kiosk to not
-  autofit or go full screen (#177)
-- Fix HTTP URLs blocked by Chromium 130+ HTTPS-First Mode (#155)
+  autofit or go full screen
+  ([#177](https://github.com/grafana/grafana-kiosk/issues/177))
+- Fix HTTP URLs blocked by Chromium 130+ HTTPS-First Mode
+  ([#155](https://github.com/grafana/grafana-kiosk/issues/155))
 - Fix CLI flags not overriding config file values when using `-c`
-  (#210)
+  ([#210](https://github.com/grafana/grafana-kiosk/issues/210))
 - Fix API key host prefix matching to prevent auth header leakage
   to hosts sharing a prefix with the target
-- Fix long lines in README.md for markdownlint compliance
 - Fix broken badge images: push shields.io JSON endpoint to `badges`
   branch from CI, use shields.io dynamic badge in README
-- Fix shellcheck warnings in CI workflow: quote variables, group
-  redirects
 
 ### Tests
 
@@ -50,6 +49,8 @@ and this project adheres to
 - Restrict CI workflow permissions: global `permissions: {}` with
   job-level `contents: write` and `pull-requests: write`
 - Add `actionlint` job to CI for GitHub Actions workflow linting
+- Fix shellcheck warnings in CI workflow: quote variables, group
+  redirects
 
 ### Dependencies
 
@@ -67,6 +68,7 @@ and this project adheres to
   versions
 - Switch to markdownlint-cli2 with `.markdownlint-cli2.yaml` config
 - Add missing technical terms to cspell config
+- Fix long lines in README.md for markdownlint compliance
 
 ## 1.0.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,44 +9,62 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Bug Fixes
+
 - Fix autofit not working on Grafana 12+ by dispatching a resize
-  event after page load (fixes #177)
-- Fix HTTP URLs blocked by Chromium 130+ HTTPS-First Mode
-  (fixes #155)
+  event after page load (#177)
+- Fix HTTP URLs blocked by Chromium 130+ HTTPS-First Mode (#155)
 - Fix CLI flags not overriding config file values when using `-c`
-  (fixes #210)
-- Update Go module dependencies: chromedp/cdproto, magefile/mage v1.17.1,
-  google.golang.org/api v0.275.0, golang.org/x/{crypto,net,sys,text},
-  google.golang.org/grpc v1.80.0, go.opentelemetry.io/otel v1.43.0,
-  cloud.google.com/go/auth v0.20.0
-- Add CLAUDE.md referencing AGENTS.md
-- Update Docker base images: golang 1.26.2-alpine,
-  dtcooper/raspberrypi-os latest digest
-- Switch to markdownlint-cli2 with `.markdownlint-cli2.yaml` config
-- Fix long lines in README.md for markdownlint compliance
-- Add missing technical terms to cspell config
+  (#210)
 - Fix API key host prefix matching to prevent auth header leakage
   to hosts sharing a prefix with the target
+- Fix long lines in README.md for markdownlint compliance
+- Fix broken badge images: push shields.io JSON endpoint to `badges`
+  branch from CI, use shields.io dynamic badge in README
+- Fix shellcheck warnings in CI workflow: quote variables, group
+  redirects
+
+### Features
+
+- Add `--incognito` flag to optionally disable Chrome incognito mode
+  ([#127](https://github.com/grafana/grafana-kiosk/issues/127))
+
+### Tests
+
 - Add tests for `IsDataSourceQueryRequest` and `IsTargetHostRequest`
   in apikey login
 - Add tests for `sanitize` in main and initialize packages
 - Add tests for `GenerateURL` playlist mode
 - Add tests for command allowlist in initialize package
+
+### CI/CD
+
 - Update `actions/upload-artifact` from v7 to v7.0.1 in CI workflow
-- Update AGENTS.md action version table to match current CI pinned versions
 - Add octocov-action to CI for test coverage reporting on PRs
 - Add `pull_request` trigger to Build CI workflow
 - Save coverage report as CI artifact
 - Disable octocov PR comment, use PR body insertion only
 - Add octocov coverage badges to README
-- Fix broken badge images: push shields.io JSON endpoint to `badges`
-  branch from CI, use shields.io dynamic badge in README
 - Restrict CI workflow permissions: global `permissions: {}` with
   job-level `contents: write` and `pull-requests: write`
 - Add `actionlint` job to CI for GitHub Actions workflow linting
-- Fix shellcheck warnings in CI workflow: quote variables, group redirects
-- Add `--incognito` flag to optionally disable Chrome incognito mode
-  ([#127](https://github.com/grafana/grafana-kiosk/issues/127))
+
+### Dependencies
+
+- Update Go module dependencies: chromedp/cdproto, magefile/mage
+  v1.17.1, google.golang.org/api v0.275.0,
+  golang.org/x/{crypto,net,sys,text}, google.golang.org/grpc v1.80.0,
+  go.opentelemetry.io/otel v1.43.0, cloud.google.com/go/auth v0.20.0
+- Update Docker base images: golang 1.26.2-alpine,
+  dtcooper/raspberrypi-os latest digest
+
+### Chores
+
+- Add CLAUDE.md referencing AGENTS.md
+- Update AGENTS.md action version table to match current CI pinned
+  versions
+- Switch to markdownlint-cli2 with `.markdownlint-cli2.yaml` config
+- Add missing technical terms to cspell config
 
 ## 1.0.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to
 
 ### Bug Fixes
 
-- Fix autofit not working on Grafana 12+ by ensuring fullscreen
-  via CDP window state cycle before navigation (#177)
+- Fix Grafana 12+ scenes viewport changes causing kiosk to not
+  autofit or go full screen (#177)
 - Fix HTTP URLs blocked by Chromium 130+ HTTPS-First Mode (#155)
 - Fix CLI flags not overriding config file values when using `-c`
   (#210)
@@ -36,6 +36,8 @@ and this project adheres to
 - Add tests for `sanitize` in main and initialize packages
 - Add tests for `GenerateURL` playlist mode
 - Add tests for command allowlist in initialize package
+- Add tests for `resetWindowState`, `waitForPageLoad`, and
+  `waitForBrowserStartup` utilities
 
 ### CI/CD
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to
 - Add tests for `sanitize` in main and initialize packages
 - Add tests for `GenerateURL` playlist mode
 - Add tests for command allowlist in initialize package
-- Add tests for `resetWindowState`, `waitForPageLoad`, and `waitForBrowserStartup` utilities
+- Add tests for `cycleWindowToSize`, `waitForPageLoad`, and `waitForBrowserStartup` utilities
 
 ### CI/CD
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to
 
 ### Bug Fixes
 
-- Fix Grafana 12+ scenes viewport changes causing kiosk to not autofit or go full screen ([#177](https://github.com/grafana/grafana-kiosk/issues/177))
+- Fix Grafana 12+ scenes viewport changes causing kiosk to not autofit panels ([#177](https://github.com/grafana/grafana-kiosk/issues/177))
 - Fix HTTP URLs blocked by Chromium 130+ HTTPS-First Mode ([#155](https://github.com/grafana/grafana-kiosk/issues/155))
 - Fix CLI flags not overriding config file values when using `-c` ([#210](https://github.com/grafana/grafana-kiosk/issues/210))
 - Fix API key host prefix matching to prevent auth header leakage to hosts sharing a prefix with the target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- Fix autofit not working on Grafana 12+ by dispatching a resize
+  event after page load (fixes #177)
 - Fix HTTP URLs blocked by Chromium 130+ HTTPS-First Mode
   (fixes #155)
 - Fix CLI flags not overriding config file values when using `-c`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to
 - Restrict CI workflow permissions: global `permissions: {}` with job-level `contents: write` and `pull-requests: write`
 - Add `actionlint` job to CI for GitHub Actions workflow linting
 - Fix shellcheck warnings in CI workflow: quote variables, group redirects
+- Add `markdownlint.yml` workflow to lint `.md` files on push to `main` and PRs
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Features
+
+- Add `--incognito` flag to optionally disable Chrome incognito mode
+  ([#127](https://github.com/grafana/grafana-kiosk/issues/127))
+
 ### Bug Fixes
 
 - Fix autofit not working on Grafana 12+ by dispatching a resize
@@ -23,11 +28,6 @@ and this project adheres to
   branch from CI, use shields.io dynamic badge in README
 - Fix shellcheck warnings in CI workflow: quote variables, group
   redirects
-
-### Features
-
-- Add `--incognito` flag to optionally disable Chrome incognito mode
-  ([#127](https://github.com/grafana/grafana-kiosk/issues/127))
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to
 
 ### Bug Fixes
 
-- Fix autofit not working on Grafana 12+ by dispatching a resize
-  event after page load (#177)
+- Fix autofit not working on Grafana 12+ by ensuring fullscreen
+  via CDP window state cycle before navigation (#177)
 - Fix HTTP URLs blocked by Chromium 130+ HTTPS-First Mode (#155)
 - Fix CLI flags not overriding config file values when using `-c`
   (#210)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,32 +11,23 @@ and this project adheres to
 
 ### Features
 
-- Add `--incognito` flag to optionally disable Chrome incognito mode
-  ([#127](https://github.com/grafana/grafana-kiosk/issues/127))
+- Add `--incognito` flag to optionally disable Chrome incognito mode ([#127](https://github.com/grafana/grafana-kiosk/issues/127))
 
 ### Bug Fixes
 
-- Fix Grafana 12+ scenes viewport changes causing kiosk to not
-  autofit or go full screen
-  ([#177](https://github.com/grafana/grafana-kiosk/issues/177))
-- Fix HTTP URLs blocked by Chromium 130+ HTTPS-First Mode
-  ([#155](https://github.com/grafana/grafana-kiosk/issues/155))
-- Fix CLI flags not overriding config file values when using `-c`
-  ([#210](https://github.com/grafana/grafana-kiosk/issues/210))
-- Fix API key host prefix matching to prevent auth header leakage
-  to hosts sharing a prefix with the target
-- Fix broken badge images: push shields.io JSON endpoint to `badges`
-  branch from CI, use shields.io dynamic badge in README
+- Fix Grafana 12+ scenes viewport changes causing kiosk to not autofit or go full screen ([#177](https://github.com/grafana/grafana-kiosk/issues/177))
+- Fix HTTP URLs blocked by Chromium 130+ HTTPS-First Mode ([#155](https://github.com/grafana/grafana-kiosk/issues/155))
+- Fix CLI flags not overriding config file values when using `-c` ([#210](https://github.com/grafana/grafana-kiosk/issues/210))
+- Fix API key host prefix matching to prevent auth header leakage to hosts sharing a prefix with the target
+- Fix broken badge images: push shields.io JSON endpoint to `badges` branch from CI, use shields.io dynamic badge in README
 
 ### Tests
 
-- Add tests for `IsDataSourceQueryRequest` and `IsTargetHostRequest`
-  in apikey login
+- Add tests for `IsDataSourceQueryRequest` and `IsTargetHostRequest` in apikey login
 - Add tests for `sanitize` in main and initialize packages
 - Add tests for `GenerateURL` playlist mode
 - Add tests for command allowlist in initialize package
-- Add tests for `resetWindowState`, `waitForPageLoad`, and
-  `waitForBrowserStartup` utilities
+- Add tests for `resetWindowState`, `waitForPageLoad`, and `waitForBrowserStartup` utilities
 
 ### CI/CD
 
@@ -46,26 +37,21 @@ and this project adheres to
 - Save coverage report as CI artifact
 - Disable octocov PR comment, use PR body insertion only
 - Add octocov coverage badges to README
-- Restrict CI workflow permissions: global `permissions: {}` with
-  job-level `contents: write` and `pull-requests: write`
+- Restrict CI workflow permissions: global `permissions: {}` with job-level `contents: write` and `pull-requests: write`
 - Add `actionlint` job to CI for GitHub Actions workflow linting
-- Fix shellcheck warnings in CI workflow: quote variables, group
-  redirects
+- Fix shellcheck warnings in CI workflow: quote variables, group redirects
 
 ### Dependencies
 
-- Update Go module dependencies: chromedp/cdproto, magefile/mage
-  v1.17.1, google.golang.org/api v0.275.0,
-  golang.org/x/{crypto,net,sys,text}, google.golang.org/grpc v1.80.0,
-  go.opentelemetry.io/otel v1.43.0, cloud.google.com/go/auth v0.20.0
-- Update Docker base images: golang 1.26.2-alpine,
-  dtcooper/raspberrypi-os latest digest
+- Update Go module dependencies: chromedp/cdproto, magefile/mage v1.17.1, google.golang.org/api v0.275.0,
+  golang.org/x/{crypto,net,sys,text}, google.golang.org/grpc v1.80.0, go.opentelemetry.io/otel v1.43.0,
+  cloud.google.com/go/auth v0.20.0
+- Update Docker base images: golang 1.26.2-alpine, dtcooper/raspberrypi-os latest digest
 
 ### Chores
 
 - Add CLAUDE.md referencing AGENTS.md
-- Update AGENTS.md action version table to match current CI pinned
-  versions
+- Update AGENTS.md action version table to match current CI pinned versions
 - Switch to markdownlint-cli2 with `.markdownlint-cli2.yaml` config
 - Add missing technical terms to cspell config
 - Fix long lines in README.md for markdownlint compliance

--- a/README.md
+++ b/README.md
@@ -225,6 +225,22 @@ They can also be used instead of a configuration file.
       Size of Kiosk in pixels (width,height) (default "")
 ```
 
+### Window size and kiosk mode
+
+By default, the kiosk launches Chrome in fullscreen kiosk mode (`--kiosk --start-fullscreen`). The `-window-size` and
+`-kiosk-mode` flags interact as follows:
+
+| `-window-size` | `-kiosk-mode` | Behavior |
+| --- | --- | --- |
+| not set | `full` (default) | Fullscreen kiosk, panels autofit to screen |
+| not set | `tv` or `disabled` | Fullscreen kiosk, no panel autofit |
+| set (e.g. `1920,1080`) | `full` (default) | App window at specified size, then cycles to fullscreen via CDP |
+| set (e.g. `1920,1080`) | `tv` or `disabled` | App window at specified size, no fullscreen |
+
+When `-window-size` is specified, Chrome launches in app mode (no address bar or controls). Before navigating to the
+dashboard, the kiosk cycles the browser window state via the Chrome DevTools Protocol (CDP) to force Chrome to properly
+register viewport dimensions. This ensures Grafana correctly applies the `autofitpanels` parameter on initial page load.
+
 ### Hosted Grafana using grafana.com authentication
 
 This will login to a Hosted Grafana instance and take the browser to the default dashboard in fullscreen kiosk mode:

--- a/pkg/cmd/grafana-kiosk/main_test.go
+++ b/pkg/cmd/grafana-kiosk/main_test.go
@@ -127,6 +127,43 @@ general:
 	})
 }
 
+func TestLoadConfigEnvOnly(t *testing.T) {
+	Convey("Given no config file and no CLI flags", t, func() {
+		oldArgs := os.Args
+		defer func() { os.Args = oldArgs }()
+		os.Args = []string{"grafana-kiosk"}
+
+		Convey("Should load defaults from environment", func() {
+			var cfg kiosk.Config
+			args, fs := ProcessArgs(&cfg)
+			err := loadConfig(args, fs, &cfg)
+			So(err, ShouldBeNil)
+			// env-defaults from struct tags
+			So(cfg.Target.URL, ShouldEqual, "https://play.grafana.org")
+			So(cfg.Target.LoginMethod, ShouldEqual, "anon")
+			So(cfg.General.AutoFit, ShouldBeTrue)
+			So(cfg.General.Mode, ShouldEqual, "full")
+		})
+
+		Convey("Should apply CLI flags over env defaults", func() {
+			os.Args = []string{
+				"grafana-kiosk",
+				"-URL", "http://localhost:3000",
+				"-kiosk-mode", "tv",
+			}
+			var cfg kiosk.Config
+			args, fs := ProcessArgs(&cfg)
+			err := loadConfig(args, fs, &cfg)
+			So(err, ShouldBeNil)
+			So(cfg.Target.URL, ShouldEqual, "http://localhost:3000")
+			So(cfg.General.Mode, ShouldEqual, "tv")
+			// non-overridden defaults preserved
+			So(cfg.General.AutoFit, ShouldBeTrue)
+			So(cfg.Target.LoginMethod, ShouldEqual, "anon")
+		})
+	})
+}
+
 func TestMain(t *testing.T) {
 	Convey("Given Default Configuration", t, func() {
 		cfg := kiosk.Config{

--- a/pkg/initialize/lxde_test.go
+++ b/pkg/initialize/lxde_test.go
@@ -75,5 +75,23 @@ func TestRunCommandAllowlist(t *testing.T) {
 				runCommand("/tmp", "", []string{"arg"}, false)
 			}, ShouldNotPanic)
 		})
+
+		Convey("When allowed command does not exist on system", func() {
+			allowedCommands["/usr/bin/nonexistent-kiosk-test"] = true
+			defer delete(allowedCommands, "/usr/bin/nonexistent-kiosk-test")
+
+			So(func() {
+				runCommand("/tmp", "/usr/bin/nonexistent-kiosk-test", []string{"arg"}, false)
+			}, ShouldNotPanic)
+		})
+
+		Convey("When allowed command fails with waitForEnd", func() {
+			allowedCommands["/usr/bin/nonexistent-kiosk-test"] = true
+			defer delete(allowedCommands, "/usr/bin/nonexistent-kiosk-test")
+
+			So(func() {
+				runCommand("/tmp", "/usr/bin/nonexistent-kiosk-test", []string{"arg"}, true)
+			}, ShouldNotPanic)
+		})
 	})
 }

--- a/pkg/kiosk/anonymous_login.go
+++ b/pkg/kiosk/anonymous_login.go
@@ -34,6 +34,7 @@ func GrafanaKioskAnonymous(ctx context.Context, cfg *Config, dir string, message
 	if err := chromedp.Run(taskCtx,
 		resetWindowState(cfg),
 		chromedp.Navigate(generatedURL),
+		waitForPageLoad(cfg),
 	); err != nil {
 		panic(err)
 	}

--- a/pkg/kiosk/anonymous_login.go
+++ b/pkg/kiosk/anonymous_login.go
@@ -36,12 +36,10 @@ func GrafanaKioskAnonymous(ctx context.Context, cfg *Config, dir string, message
 
 	if err := chromedp.Run(taskCtx,
 		chromedp.Navigate(generatedURL),
+		triggerAutofit(cfg),
 	); err != nil {
 		panic(err)
 	}
-	// Give browser time to fully render the dashboard
-	log.Printf("Sleeping %d MS before continuing", cfg.General.PageLoadDelayMS)
-	time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
 	// blocking wait until context is cancelled or a message triggers a reload
 	for {
 		select {
@@ -50,6 +48,7 @@ func GrafanaKioskAnonymous(ctx context.Context, cfg *Config, dir string, message
 		case messageFromChrome := <-messages:
 			if err := chromedp.Run(taskCtx,
 				chromedp.Navigate(generatedURL),
+				triggerAutofit(cfg),
 			); err != nil {
 				return
 			}

--- a/pkg/kiosk/anonymous_login.go
+++ b/pkg/kiosk/anonymous_login.go
@@ -36,7 +36,7 @@ func GrafanaKioskAnonymous(ctx context.Context, cfg *Config, dir string, message
 
 	if err := chromedp.Run(taskCtx,
 		chromedp.Navigate(generatedURL),
-		triggerAutofit(cfg),
+		postNavigate(cfg),
 	); err != nil {
 		panic(err)
 	}
@@ -48,7 +48,7 @@ func GrafanaKioskAnonymous(ctx context.Context, cfg *Config, dir string, message
 		case messageFromChrome := <-messages:
 			if err := chromedp.Run(taskCtx,
 				chromedp.Navigate(generatedURL),
-				triggerAutofit(cfg),
+				postNavigate(cfg),
 			); err != nil {
 				return
 			}

--- a/pkg/kiosk/anonymous_login.go
+++ b/pkg/kiosk/anonymous_login.go
@@ -3,7 +3,6 @@ package kiosk
 import (
 	"context"
 	"log"
-	"time"
 
 	"github.com/chromedp/chromedp"
 )
@@ -26,17 +25,15 @@ func GrafanaKioskAnonymous(ctx context.Context, cfg *Config, dir string, message
 		panic(err)
 	}
 
-	// Give browser time to load
-	log.Printf("Sleeping %d MS before navigating to url", cfg.General.PageLoadDelayMS)
-	time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
+	waitForBrowserStartup(cfg)
 
 	var generatedURL = GenerateURL(cfg)
 
 	log.Println("Navigating to ", generatedURL)
 
 	if err := chromedp.Run(taskCtx,
+		resetWindowState(cfg),
 		chromedp.Navigate(generatedURL),
-		postNavigate(cfg),
 	); err != nil {
 		panic(err)
 	}
@@ -48,7 +45,6 @@ func GrafanaKioskAnonymous(ctx context.Context, cfg *Config, dir string, message
 		case messageFromChrome := <-messages:
 			if err := chromedp.Run(taskCtx,
 				chromedp.Navigate(generatedURL),
-				postNavigate(cfg),
 			); err != nil {
 				return
 			}

--- a/pkg/kiosk/anonymous_login.go
+++ b/pkg/kiosk/anonymous_login.go
@@ -32,7 +32,7 @@ func GrafanaKioskAnonymous(ctx context.Context, cfg *Config, dir string, message
 	log.Println("Navigating to ", generatedURL)
 
 	if err := chromedp.Run(taskCtx,
-		resetWindowState(cfg),
+		cycleWindowState(cfg),
 		chromedp.Navigate(generatedURL),
 		waitForPageLoad(cfg),
 	); err != nil {

--- a/pkg/kiosk/apikey_login.go
+++ b/pkg/kiosk/apikey_login.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/chromedp/cdproto/fetch"
 	"github.com/chromedp/chromedp"
@@ -52,9 +51,7 @@ func GrafanaKioskAPIKey(ctx context.Context, cfg *Config, dir string, messages c
 		panic(err)
 	}
 
-	// Give browser time to load
-	log.Printf("Sleeping %d MS before navigating to url", cfg.General.PageLoadDelayMS)
-	time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
+	waitForBrowserStartup(cfg)
 
 	var generatedURL = GenerateURL(cfg)
 
@@ -102,9 +99,9 @@ func GrafanaKioskAPIKey(ctx context.Context, cfg *Config, dir string, messages c
 	})
 	if err := chromedp.Run(
 		taskCtx,
+		resetWindowState(cfg),
 		fetch.Enable().WithPatterns([]*fetch.RequestPattern{{URLPattern: u.Scheme + "://" + u.Host + "/*"}}),
 		chromedp.Navigate(generatedURL),
-		postNavigate(cfg),
 	); err != nil {
 		panic(err)
 	}
@@ -116,7 +113,6 @@ func GrafanaKioskAPIKey(ctx context.Context, cfg *Config, dir string, messages c
 		case messageFromChrome := <-messages:
 			if err := chromedp.Run(taskCtx,
 				chromedp.Navigate(generatedURL),
-				postNavigate(cfg),
 			); err != nil {
 				return
 			}

--- a/pkg/kiosk/apikey_login.go
+++ b/pkg/kiosk/apikey_login.go
@@ -104,12 +104,10 @@ func GrafanaKioskAPIKey(ctx context.Context, cfg *Config, dir string, messages c
 		taskCtx,
 		fetch.Enable().WithPatterns([]*fetch.RequestPattern{{URLPattern: u.Scheme + "://" + u.Host + "/*"}}),
 		chromedp.Navigate(generatedURL),
+		triggerAutofit(cfg),
 	); err != nil {
 		panic(err)
 	}
-	// Give browser time to fully render the dashboard
-	log.Printf("Sleeping %d MS before continuing", cfg.General.PageLoadDelayMS)
-	time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
 	// blocking wait until context is cancelled or a message triggers a reload
 	for {
 		select {
@@ -118,6 +116,7 @@ func GrafanaKioskAPIKey(ctx context.Context, cfg *Config, dir string, messages c
 		case messageFromChrome := <-messages:
 			if err := chromedp.Run(taskCtx,
 				chromedp.Navigate(generatedURL),
+				triggerAutofit(cfg),
 			); err != nil {
 				return
 			}

--- a/pkg/kiosk/apikey_login.go
+++ b/pkg/kiosk/apikey_login.go
@@ -102,6 +102,7 @@ func GrafanaKioskAPIKey(ctx context.Context, cfg *Config, dir string, messages c
 		resetWindowState(cfg),
 		fetch.Enable().WithPatterns([]*fetch.RequestPattern{{URLPattern: u.Scheme + "://" + u.Host + "/*"}}),
 		chromedp.Navigate(generatedURL),
+		waitForPageLoad(cfg),
 	); err != nil {
 		panic(err)
 	}

--- a/pkg/kiosk/apikey_login.go
+++ b/pkg/kiosk/apikey_login.go
@@ -104,7 +104,7 @@ func GrafanaKioskAPIKey(ctx context.Context, cfg *Config, dir string, messages c
 		taskCtx,
 		fetch.Enable().WithPatterns([]*fetch.RequestPattern{{URLPattern: u.Scheme + "://" + u.Host + "/*"}}),
 		chromedp.Navigate(generatedURL),
-		triggerAutofit(cfg),
+		postNavigate(cfg),
 	); err != nil {
 		panic(err)
 	}
@@ -116,7 +116,7 @@ func GrafanaKioskAPIKey(ctx context.Context, cfg *Config, dir string, messages c
 		case messageFromChrome := <-messages:
 			if err := chromedp.Run(taskCtx,
 				chromedp.Navigate(generatedURL),
-				triggerAutofit(cfg),
+				postNavigate(cfg),
 			); err != nil {
 				return
 			}

--- a/pkg/kiosk/apikey_login.go
+++ b/pkg/kiosk/apikey_login.go
@@ -99,7 +99,7 @@ func GrafanaKioskAPIKey(ctx context.Context, cfg *Config, dir string, messages c
 	})
 	if err := chromedp.Run(
 		taskCtx,
-		resetWindowState(cfg),
+		cycleWindowState(cfg),
 		fetch.Enable().WithPatterns([]*fetch.RequestPattern{{URLPattern: u.Scheme + "://" + u.Host + "/*"}}),
 		chromedp.Navigate(generatedURL),
 		waitForPageLoad(cfg),

--- a/pkg/kiosk/aws_login.go
+++ b/pkg/kiosk/aws_login.go
@@ -33,6 +33,7 @@ func GrafanaKioskAWSLogin(ctx context.Context, cfg *Config, dir string, messages
 	log.Println("Navigating to ", generatedURL)
 
 	if err := chromedp.Run(taskCtx,
+		waitForPageLoad(cfg),
 		resetWindowState(cfg),
 		chromedp.Navigate(generatedURL),
 		chromedp.WaitVisible(`//a[contains(@href,'login/sso')]`, chromedp.BySearch),

--- a/pkg/kiosk/aws_login.go
+++ b/pkg/kiosk/aws_login.go
@@ -58,7 +58,7 @@ func GrafanaKioskAWSLogin(ctx context.Context, cfg *Config, dir string, messages
 			panic(err)
 		}
 	}
-	if err := chromedp.Run(taskCtx, triggerAutofit(cfg)); err != nil {
+	if err := chromedp.Run(taskCtx, postNavigate(cfg)); err != nil {
 		panic(err)
 	}
 
@@ -70,7 +70,7 @@ func GrafanaKioskAWSLogin(ctx context.Context, cfg *Config, dir string, messages
 		case messageFromChrome := <-messages:
 			if err := chromedp.Run(taskCtx,
 				chromedp.Navigate(generatedURL),
-				triggerAutofit(cfg),
+				postNavigate(cfg),
 			); err != nil {
 				return
 			}

--- a/pkg/kiosk/aws_login.go
+++ b/pkg/kiosk/aws_login.go
@@ -34,7 +34,7 @@ func GrafanaKioskAWSLogin(ctx context.Context, cfg *Config, dir string, messages
 
 	if err := chromedp.Run(taskCtx,
 		waitForPageLoad(cfg),
-		resetWindowState(cfg),
+		cycleWindowState(cfg),
 		chromedp.Navigate(generatedURL),
 		chromedp.WaitVisible(`//a[contains(@href,'login/sso')]`, chromedp.BySearch),
 		chromedp.WaitVisible(`div#awsccc-cb-buttons`, chromedp.BySearch),

--- a/pkg/kiosk/aws_login.go
+++ b/pkg/kiosk/aws_login.go
@@ -3,7 +3,6 @@ package kiosk
 import (
 	"context"
 	"log"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/chromedp/chromedp/kb"
@@ -21,23 +20,20 @@ func GrafanaKioskAWSLogin(ctx context.Context, cfg *Config, dir string, messages
 	defer cancel()
 
 	listenChromeEvents(taskCtx, cfg, targetCrashed)
-	// Give browser time to load
-	log.Printf("Sleeping %d MS before navigating to url", cfg.General.PageLoadDelayMS)
-	time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
 
 	// ensure that the browser process is started
 	if err := chromedp.Run(taskCtx); err != nil {
 		panic(err)
 	}
 
+	waitForBrowserStartup(cfg)
+
 	var generatedURL = GenerateURL(cfg)
 
 	log.Println("Navigating to ", generatedURL)
 
-	// Give browser time to load next page (this can be prone to failure, explore different options vs sleeping)
-	time.Sleep(2000 * time.Millisecond)
-
 	if err := chromedp.Run(taskCtx,
+		resetWindowState(cfg),
 		chromedp.Navigate(generatedURL),
 		chromedp.WaitVisible(`//a[contains(@href,'login/sso')]`, chromedp.BySearch),
 		chromedp.WaitVisible(`div#awsccc-cb-buttons`, chromedp.BySearch),
@@ -58,10 +54,6 @@ func GrafanaKioskAWSLogin(ctx context.Context, cfg *Config, dir string, messages
 			panic(err)
 		}
 	}
-	if err := chromedp.Run(taskCtx, postNavigate(cfg)); err != nil {
-		panic(err)
-	}
-
 	// blocking wait until context is cancelled or a message triggers a reload
 	for {
 		select {
@@ -70,7 +62,6 @@ func GrafanaKioskAWSLogin(ctx context.Context, cfg *Config, dir string, messages
 		case messageFromChrome := <-messages:
 			if err := chromedp.Run(taskCtx,
 				chromedp.Navigate(generatedURL),
-				postNavigate(cfg),
 			); err != nil {
 				return
 			}

--- a/pkg/kiosk/aws_login.go
+++ b/pkg/kiosk/aws_login.go
@@ -58,6 +58,9 @@ func GrafanaKioskAWSLogin(ctx context.Context, cfg *Config, dir string, messages
 			panic(err)
 		}
 	}
+	if err := chromedp.Run(taskCtx, triggerAutofit(cfg)); err != nil {
+		panic(err)
+	}
 
 	// blocking wait until context is cancelled or a message triggers a reload
 	for {
@@ -67,6 +70,7 @@ func GrafanaKioskAWSLogin(ctx context.Context, cfg *Config, dir string, messages
 		case messageFromChrome := <-messages:
 			if err := chromedp.Run(taskCtx,
 				chromedp.Navigate(generatedURL),
+				triggerAutofit(cfg),
 			); err != nil {
 				return
 			}

--- a/pkg/kiosk/azuread_login.go
+++ b/pkg/kiosk/azuread_login.go
@@ -107,7 +107,7 @@ func GrafanaKioskAzureAD(ctx context.Context, cfg *Config, dir string, messages 
 		panic(err)
 	}
 
-	if err := chromedp.Run(taskCtx, triggerAutofit(cfg)); err != nil {
+	if err := chromedp.Run(taskCtx, postNavigate(cfg)); err != nil {
 		panic(err)
 	}
 
@@ -116,7 +116,7 @@ func GrafanaKioskAzureAD(ctx context.Context, cfg *Config, dir string, messages 
 		messageFromChrome := <-messages
 		if err := chromedp.Run(taskCtx,
 			chromedp.Navigate(generatedURL),
-			triggerAutofit(cfg),
+			postNavigate(cfg),
 		); err != nil {
 			panic(err)
 		}

--- a/pkg/kiosk/azuread_login.go
+++ b/pkg/kiosk/azuread_login.go
@@ -45,7 +45,7 @@ func GrafanaKioskAzureAD(ctx context.Context, cfg *Config, dir string, messages 
 	// Click the AzureAD login button on the Grafana login page
 	if err := chromedp.Run(taskCtx,
 		waitForPageLoad(cfg),
-		resetWindowState(cfg),
+		cycleWindowState(cfg),
 		chromedp.Navigate(generatedURL),
 		chromedp.ActionFunc(func(context.Context) error {
 			log.Println("waiting for azuread login button")

--- a/pkg/kiosk/azuread_login.go
+++ b/pkg/kiosk/azuread_login.go
@@ -26,9 +26,7 @@ func GrafanaKioskAzureAD(ctx context.Context, cfg *Config, dir string, messages 
 		panic(err)
 	}
 
-	// Give browser time to load
-	log.Printf("Sleeping %d MS before navigating to url", cfg.General.PageLoadDelayMS)
-	time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
+	waitForBrowserStartup(cfg)
 
 	var generatedURL = GenerateURL(cfg)
 
@@ -46,6 +44,8 @@ func GrafanaKioskAzureAD(ctx context.Context, cfg *Config, dir string, messages 
 
 	// Click the AzureAD login button on the Grafana login page
 	if err := chromedp.Run(taskCtx,
+		waitForPageLoad(cfg),
+		resetWindowState(cfg),
 		chromedp.Navigate(generatedURL),
 		chromedp.ActionFunc(func(context.Context) error {
 			log.Println("waiting for azuread login button")
@@ -107,16 +107,11 @@ func GrafanaKioskAzureAD(ctx context.Context, cfg *Config, dir string, messages 
 		panic(err)
 	}
 
-	if err := chromedp.Run(taskCtx, postNavigate(cfg)); err != nil {
-		panic(err)
-	}
-
 	// blocking wait for reload messages
 	for {
 		messageFromChrome := <-messages
 		if err := chromedp.Run(taskCtx,
 			chromedp.Navigate(generatedURL),
-			postNavigate(cfg),
 		); err != nil {
 			panic(err)
 		}

--- a/pkg/kiosk/azuread_login.go
+++ b/pkg/kiosk/azuread_login.go
@@ -107,11 +107,16 @@ func GrafanaKioskAzureAD(ctx context.Context, cfg *Config, dir string, messages 
 		panic(err)
 	}
 
+	if err := chromedp.Run(taskCtx, triggerAutofit(cfg)); err != nil {
+		panic(err)
+	}
+
 	// blocking wait for reload messages
 	for {
 		messageFromChrome := <-messages
 		if err := chromedp.Run(taskCtx,
 			chromedp.Navigate(generatedURL),
+			triggerAutofit(cfg),
 		); err != nil {
 			panic(err)
 		}

--- a/pkg/kiosk/grafana_com_login.go
+++ b/pkg/kiosk/grafana_com_login.go
@@ -3,6 +3,7 @@ package kiosk
 import (
 	"context"
 	"log"
+	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/chromedp/chromedp/kb"
@@ -61,8 +62,9 @@ func GrafanaKioskGCOM(ctx context.Context, cfg *Config, dir string, messages cha
 	); err != nil {
 		panic(err)
 	}
+	// Give browser time to load next page (this can be prone to failure, explore different options vs sleeping)
+	time.Sleep(3000 * time.Millisecond)
 	// Fill out grafana_com login page
-	waitForBrowserStartup(cfg)
 	if err := chromedp.Run(taskCtx,
 		chromedp.WaitVisible(`//input[@name="login"]`, chromedp.BySearch),
 		chromedp.SendKeys(`//input[@name="login"]`, cfg.Target.Username, chromedp.BySearch),

--- a/pkg/kiosk/grafana_com_login.go
+++ b/pkg/kiosk/grafana_com_login.go
@@ -3,7 +3,6 @@ package kiosk
 import (
 	"context"
 	"log"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/chromedp/chromedp/kb"
@@ -26,9 +25,8 @@ func GrafanaKioskGCOM(ctx context.Context, cfg *Config, dir string, messages cha
 	if err := chromedp.Run(taskCtx); err != nil {
 		panic(err)
 	}
-	// Give browser time to load
-	log.Printf("Sleeping %d MS before navigating to url", cfg.General.PageLoadDelayMS)
-	time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
+
+	waitForBrowserStartup(cfg)
 
 	var generatedURL = GenerateURL(cfg)
 
@@ -43,6 +41,8 @@ func GrafanaKioskGCOM(ctx context.Context, cfg *Config, dir string, messages cha
 
 	// Click the grafana_com login button
 	if err := chromedp.Run(taskCtx,
+		waitForPageLoad(cfg),
+		resetWindowState(cfg),
 		chromedp.Navigate(generatedURL),
 		chromedp.ActionFunc(func(context.Context) error {
 			log.Println("waiting for login dialog")
@@ -61,18 +61,14 @@ func GrafanaKioskGCOM(ctx context.Context, cfg *Config, dir string, messages cha
 	); err != nil {
 		panic(err)
 	}
-	// Give browser time to load next page (this can be prone to failure, explore different options vs sleeping)
-	time.Sleep(3000 * time.Millisecond)
 	// Fill out grafana_com login page
+	waitForBrowserStartup(cfg)
 	if err := chromedp.Run(taskCtx,
 		chromedp.WaitVisible(`//input[@name="login"]`, chromedp.BySearch),
 		chromedp.SendKeys(`//input[@name="login"]`, cfg.Target.Username, chromedp.BySearch),
 		chromedp.Click(`#submit`, chromedp.ByID),
 		chromedp.SendKeys(`//input[@name="password"]`, cfg.Target.Password+kb.Enter, chromedp.BySearch),
 	); err != nil {
-		panic(err)
-	}
-	if err := chromedp.Run(taskCtx, postNavigate(cfg)); err != nil {
 		panic(err)
 	}
 	// blocking wait until context is cancelled or a message triggers a reload
@@ -83,7 +79,6 @@ func GrafanaKioskGCOM(ctx context.Context, cfg *Config, dir string, messages cha
 		case messageFromChrome := <-messages:
 			if err := chromedp.Run(taskCtx,
 				chromedp.Navigate(generatedURL),
-				postNavigate(cfg),
 			); err != nil {
 				return
 			}

--- a/pkg/kiosk/grafana_com_login.go
+++ b/pkg/kiosk/grafana_com_login.go
@@ -43,7 +43,7 @@ func GrafanaKioskGCOM(ctx context.Context, cfg *Config, dir string, messages cha
 	// Click the grafana_com login button
 	if err := chromedp.Run(taskCtx,
 		waitForPageLoad(cfg),
-		resetWindowState(cfg),
+		cycleWindowState(cfg),
 		chromedp.Navigate(generatedURL),
 		chromedp.ActionFunc(func(context.Context) error {
 			log.Println("waiting for login dialog")

--- a/pkg/kiosk/grafana_com_login.go
+++ b/pkg/kiosk/grafana_com_login.go
@@ -72,7 +72,7 @@ func GrafanaKioskGCOM(ctx context.Context, cfg *Config, dir string, messages cha
 	); err != nil {
 		panic(err)
 	}
-	if err := chromedp.Run(taskCtx, triggerAutofit(cfg)); err != nil {
+	if err := chromedp.Run(taskCtx, postNavigate(cfg)); err != nil {
 		panic(err)
 	}
 	// blocking wait until context is cancelled or a message triggers a reload
@@ -83,7 +83,7 @@ func GrafanaKioskGCOM(ctx context.Context, cfg *Config, dir string, messages cha
 		case messageFromChrome := <-messages:
 			if err := chromedp.Run(taskCtx,
 				chromedp.Navigate(generatedURL),
-				triggerAutofit(cfg),
+				postNavigate(cfg),
 			); err != nil {
 				return
 			}

--- a/pkg/kiosk/grafana_com_login.go
+++ b/pkg/kiosk/grafana_com_login.go
@@ -72,6 +72,9 @@ func GrafanaKioskGCOM(ctx context.Context, cfg *Config, dir string, messages cha
 	); err != nil {
 		panic(err)
 	}
+	if err := chromedp.Run(taskCtx, triggerAutofit(cfg)); err != nil {
+		panic(err)
+	}
 	// blocking wait until context is cancelled or a message triggers a reload
 	for {
 		select {
@@ -80,6 +83,7 @@ func GrafanaKioskGCOM(ctx context.Context, cfg *Config, dir string, messages cha
 		case messageFromChrome := <-messages:
 			if err := chromedp.Run(taskCtx,
 				chromedp.Navigate(generatedURL),
+				triggerAutofit(cfg),
 			); err != nil {
 				return
 			}

--- a/pkg/kiosk/grafana_genericoauth_login.go
+++ b/pkg/kiosk/grafana_genericoauth_login.go
@@ -87,6 +87,9 @@ func GrafanaKioskGenericOauth(ctx context.Context, cfg *Config, dir string, mess
 			panic(err)
 		}
 	}
+	if err := chromedp.Run(taskCtx, triggerAutofit(cfg)); err != nil {
+		panic(err)
+	}
 	// blocking wait until context is cancelled or a message triggers a reload
 	for {
 		select {
@@ -95,6 +98,7 @@ func GrafanaKioskGenericOauth(ctx context.Context, cfg *Config, dir string, mess
 		case messageFromChrome := <-messages:
 			if err := chromedp.Run(taskCtx,
 				chromedp.Navigate(generatedURL),
+				triggerAutofit(cfg),
 			); err != nil {
 				return
 			}

--- a/pkg/kiosk/grafana_genericoauth_login.go
+++ b/pkg/kiosk/grafana_genericoauth_login.go
@@ -3,7 +3,6 @@ package kiosk
 import (
 	"context"
 	"log"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/chromedp/chromedp/kb"
@@ -27,6 +26,8 @@ func GrafanaKioskGenericOauth(ctx context.Context, cfg *Config, dir string, mess
 		panic(err)
 	}
 
+	waitForBrowserStartup(cfg)
+
 	var generatedURL = GenerateURL(cfg)
 
 	log.Println("Navigating to ", generatedURL)
@@ -41,12 +42,16 @@ func GrafanaKioskGenericOauth(ctx context.Context, cfg *Config, dir string, mess
 
 	if cfg.GoAuth.AutoLogin {
 		if err := chromedp.Run(taskCtx,
+			waitForPageLoad(cfg),
+			resetWindowState(cfg),
 			chromedp.Navigate(generatedURL),
 		); err != nil {
 			panic(err)
 		}
 	} else {
 		if err := chromedp.Run(taskCtx,
+			waitForPageLoad(cfg),
+			resetWindowState(cfg),
 			chromedp.Navigate(generatedURL),
 			chromedp.WaitVisible(`//*[@href="login/generic_oauth"]`, chromedp.BySearch),
 			chromedp.Click(`//*[@href="login/generic_oauth"]`, chromedp.BySearch),
@@ -55,9 +60,7 @@ func GrafanaKioskGenericOauth(ctx context.Context, cfg *Config, dir string, mess
 		}
 	}
 
-	// Give browser time to load
-	log.Printf("Sleeping %d MS before navigating to url", cfg.General.PageLoadDelayMS)
-	time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
+	waitForBrowserStartup(cfg)
 
 	// Fill out OAUTH login page
 
@@ -87,9 +90,6 @@ func GrafanaKioskGenericOauth(ctx context.Context, cfg *Config, dir string, mess
 			panic(err)
 		}
 	}
-	if err := chromedp.Run(taskCtx, postNavigate(cfg)); err != nil {
-		panic(err)
-	}
 	// blocking wait until context is cancelled or a message triggers a reload
 	for {
 		select {
@@ -98,7 +98,6 @@ func GrafanaKioskGenericOauth(ctx context.Context, cfg *Config, dir string, mess
 		case messageFromChrome := <-messages:
 			if err := chromedp.Run(taskCtx,
 				chromedp.Navigate(generatedURL),
-				postNavigate(cfg),
 			); err != nil {
 				return
 			}

--- a/pkg/kiosk/grafana_genericoauth_login.go
+++ b/pkg/kiosk/grafana_genericoauth_login.go
@@ -87,7 +87,7 @@ func GrafanaKioskGenericOauth(ctx context.Context, cfg *Config, dir string, mess
 			panic(err)
 		}
 	}
-	if err := chromedp.Run(taskCtx, triggerAutofit(cfg)); err != nil {
+	if err := chromedp.Run(taskCtx, postNavigate(cfg)); err != nil {
 		panic(err)
 	}
 	// blocking wait until context is cancelled or a message triggers a reload
@@ -98,7 +98,7 @@ func GrafanaKioskGenericOauth(ctx context.Context, cfg *Config, dir string, mess
 		case messageFromChrome := <-messages:
 			if err := chromedp.Run(taskCtx,
 				chromedp.Navigate(generatedURL),
-				triggerAutofit(cfg),
+				postNavigate(cfg),
 			); err != nil {
 				return
 			}

--- a/pkg/kiosk/grafana_genericoauth_login.go
+++ b/pkg/kiosk/grafana_genericoauth_login.go
@@ -43,7 +43,7 @@ func GrafanaKioskGenericOauth(ctx context.Context, cfg *Config, dir string, mess
 	if cfg.GoAuth.AutoLogin {
 		if err := chromedp.Run(taskCtx,
 			waitForPageLoad(cfg),
-			resetWindowState(cfg),
+			cycleWindowState(cfg),
 			chromedp.Navigate(generatedURL),
 		); err != nil {
 			panic(err)
@@ -51,7 +51,7 @@ func GrafanaKioskGenericOauth(ctx context.Context, cfg *Config, dir string, mess
 	} else {
 		if err := chromedp.Run(taskCtx,
 			waitForPageLoad(cfg),
-			resetWindowState(cfg),
+			cycleWindowState(cfg),
 			chromedp.Navigate(generatedURL),
 			chromedp.WaitVisible(`//*[@href="login/generic_oauth"]`, chromedp.BySearch),
 			chromedp.Click(`//*[@href="login/generic_oauth"]`, chromedp.BySearch),

--- a/pkg/kiosk/grafana_idtoken_login.go
+++ b/pkg/kiosk/grafana_idtoken_login.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/fetch"
@@ -33,9 +32,7 @@ func GrafanaKioskIDToken(ctx context.Context, cfg *Config, dir string, messages 
 		panic(err)
 	}
 
-	// Give browser time to load
-	log.Printf("Sleeping %d MS before navigating to url", cfg.General.PageLoadDelayMS)
-	time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
+	waitForBrowserStartup(cfg)
 
 	var generatedURL = GenerateURL(cfg)
 
@@ -70,10 +67,7 @@ func GrafanaKioskIDToken(ctx context.Context, cfg *Config, dir string, messages 
 		}
 	})
 
-	if err := chromedp.Run(taskCtx, enableFetch(generatedURL)); err != nil {
-		panic(err)
-	}
-	if err := chromedp.Run(taskCtx, postNavigate(cfg)); err != nil {
+	if err := chromedp.Run(taskCtx, waitForPageLoad(cfg), resetWindowState(cfg), enableFetch(generatedURL)); err != nil {
 		panic(err)
 	}
 
@@ -85,7 +79,6 @@ func GrafanaKioskIDToken(ctx context.Context, cfg *Config, dir string, messages 
 		case messageFromChrome := <-messages:
 			if err := chromedp.Run(taskCtx,
 				chromedp.Navigate(generatedURL),
-				postNavigate(cfg),
 			); err != nil {
 				return
 			}

--- a/pkg/kiosk/grafana_idtoken_login.go
+++ b/pkg/kiosk/grafana_idtoken_login.go
@@ -69,7 +69,7 @@ func GrafanaKioskIDToken(ctx context.Context, cfg *Config, dir string, messages 
 
 	if err := chromedp.Run(taskCtx,
 		waitForPageLoad(cfg),
-		resetWindowState(cfg),
+		cycleWindowState(cfg),
 		enableFetch(generatedURL),
 	); err != nil {
 		panic(err)

--- a/pkg/kiosk/grafana_idtoken_login.go
+++ b/pkg/kiosk/grafana_idtoken_login.go
@@ -67,7 +67,11 @@ func GrafanaKioskIDToken(ctx context.Context, cfg *Config, dir string, messages 
 		}
 	})
 
-	if err := chromedp.Run(taskCtx, waitForPageLoad(cfg), resetWindowState(cfg), enableFetch(generatedURL)); err != nil {
+	if err := chromedp.Run(taskCtx,
+		waitForPageLoad(cfg),
+		resetWindowState(cfg),
+		enableFetch(generatedURL),
+	); err != nil {
 		panic(err)
 	}
 

--- a/pkg/kiosk/grafana_idtoken_login.go
+++ b/pkg/kiosk/grafana_idtoken_login.go
@@ -73,7 +73,7 @@ func GrafanaKioskIDToken(ctx context.Context, cfg *Config, dir string, messages 
 	if err := chromedp.Run(taskCtx, enableFetch(generatedURL)); err != nil {
 		panic(err)
 	}
-	if err := chromedp.Run(taskCtx, triggerAutofit(cfg)); err != nil {
+	if err := chromedp.Run(taskCtx, postNavigate(cfg)); err != nil {
 		panic(err)
 	}
 
@@ -85,7 +85,7 @@ func GrafanaKioskIDToken(ctx context.Context, cfg *Config, dir string, messages 
 		case messageFromChrome := <-messages:
 			if err := chromedp.Run(taskCtx,
 				chromedp.Navigate(generatedURL),
-				triggerAutofit(cfg),
+				postNavigate(cfg),
 			); err != nil {
 				return
 			}

--- a/pkg/kiosk/grafana_idtoken_login.go
+++ b/pkg/kiosk/grafana_idtoken_login.go
@@ -73,6 +73,9 @@ func GrafanaKioskIDToken(ctx context.Context, cfg *Config, dir string, messages 
 	if err := chromedp.Run(taskCtx, enableFetch(generatedURL)); err != nil {
 		panic(err)
 	}
+	if err := chromedp.Run(taskCtx, triggerAutofit(cfg)); err != nil {
+		panic(err)
+	}
 
 	// blocking wait until context is cancelled or a message triggers a reload
 	for {
@@ -82,6 +85,7 @@ func GrafanaKioskIDToken(ctx context.Context, cfg *Config, dir string, messages 
 		case messageFromChrome := <-messages:
 			if err := chromedp.Run(taskCtx,
 				chromedp.Navigate(generatedURL),
+				triggerAutofit(cfg),
 			); err != nil {
 				return
 			}

--- a/pkg/kiosk/local_login.go
+++ b/pkg/kiosk/local_login.go
@@ -63,7 +63,7 @@ func GrafanaKioskLocal(ctx context.Context, cfg *Config, dir string, messages ch
 
 		if err := chromedp.Run(taskCtx,
 			waitForPageLoad(cfg),
-			resetWindowState(cfg),
+			cycleWindowState(cfg),
 			chromedp.Navigate(bypassURL),
 			chromedp.ActionFunc(func(context.Context) error {
 				log.Printf("Sleeping %d MS before checking for login fields", cfg.General.PageLoadDelayMS)
@@ -91,7 +91,7 @@ func GrafanaKioskLocal(ctx context.Context, cfg *Config, dir string, messages ch
 	} else {
 		if err := chromedp.Run(taskCtx,
 			waitForPageLoad(cfg),
-			resetWindowState(cfg),
+			cycleWindowState(cfg),
 			chromedp.ActionFunc(func(context.Context) error {
 				log.Printf("Sleeping %d MS before navigating to final url", cfg.General.PageLoadDelayMS)
 				time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)

--- a/pkg/kiosk/local_login.go
+++ b/pkg/kiosk/local_login.go
@@ -44,6 +44,8 @@ func GrafanaKioskLocal(ctx context.Context, cfg *Config, dir string, messages ch
 		panic(err)
 	}
 
+	waitForBrowserStartup(cfg)
+
 	var generatedURL = GenerateURL(cfg)
 
 	log.Println("Navigating to ", generatedURL)
@@ -53,10 +55,6 @@ func GrafanaKioskLocal(ctx context.Context, cfg *Config, dir string, messages ch
 		name=user, type=text
 		id=inputPassword, type=password, name=password
 	*/
-	// Give browser time to load
-	log.Printf("Sleeping %d MS before navigating to url", cfg.General.PageLoadDelayMS)
-	time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
-
 	if cfg.GoAuth.AutoLogin {
 		// if AutoLogin is set, get the base URL and append the local login bypass before navigating to the full url
 		bypassURL := LocalLoginBypassURL(cfg.Target.URL)
@@ -64,6 +62,8 @@ func GrafanaKioskLocal(ctx context.Context, cfg *Config, dir string, messages ch
 		log.Println("Bypassing autoLogin using URL ", bypassURL)
 
 		if err := chromedp.Run(taskCtx,
+			waitForPageLoad(cfg),
+			resetWindowState(cfg),
 			chromedp.Navigate(bypassURL),
 			chromedp.ActionFunc(func(context.Context) error {
 				log.Printf("Sleeping %d MS before checking for login fields", cfg.General.PageLoadDelayMS)
@@ -85,12 +85,13 @@ func GrafanaKioskLocal(ctx context.Context, cfg *Config, dir string, messages ch
 				return nil
 			}),
 			chromedp.Navigate(generatedURL),
-			postNavigate(cfg),
 		); err != nil {
 			panic(err)
 		}
 	} else {
 		if err := chromedp.Run(taskCtx,
+			waitForPageLoad(cfg),
+			resetWindowState(cfg),
 			chromedp.ActionFunc(func(context.Context) error {
 				log.Printf("Sleeping %d MS before navigating to final url", cfg.General.PageLoadDelayMS)
 				time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
@@ -105,7 +106,6 @@ func GrafanaKioskLocal(ctx context.Context, cfg *Config, dir string, messages ch
 			chromedp.WaitVisible(`//input[@name="user"]`, chromedp.BySearch),
 			chromedp.SendKeys(`//input[@name="user"]`, cfg.Target.Username, chromedp.BySearch),
 			chromedp.SendKeys(`//input[@name="password"]`, cfg.Target.Password+kb.Enter, chromedp.BySearch),
-			postNavigate(cfg),
 		); err != nil {
 			panic(err)
 		}
@@ -119,7 +119,6 @@ func GrafanaKioskLocal(ctx context.Context, cfg *Config, dir string, messages ch
 		case messageFromChrome := <-messages:
 			if err := chromedp.Run(taskCtx,
 				chromedp.Navigate(generatedURL),
-				postNavigate(cfg),
 			); err != nil {
 				return
 			}

--- a/pkg/kiosk/local_login.go
+++ b/pkg/kiosk/local_login.go
@@ -85,7 +85,7 @@ func GrafanaKioskLocal(ctx context.Context, cfg *Config, dir string, messages ch
 				return nil
 			}),
 			chromedp.Navigate(generatedURL),
-			triggerAutofit(cfg),
+			postNavigate(cfg),
 		); err != nil {
 			panic(err)
 		}
@@ -105,7 +105,7 @@ func GrafanaKioskLocal(ctx context.Context, cfg *Config, dir string, messages ch
 			chromedp.WaitVisible(`//input[@name="user"]`, chromedp.BySearch),
 			chromedp.SendKeys(`//input[@name="user"]`, cfg.Target.Username, chromedp.BySearch),
 			chromedp.SendKeys(`//input[@name="password"]`, cfg.Target.Password+kb.Enter, chromedp.BySearch),
-			triggerAutofit(cfg),
+			postNavigate(cfg),
 		); err != nil {
 			panic(err)
 		}
@@ -119,7 +119,7 @@ func GrafanaKioskLocal(ctx context.Context, cfg *Config, dir string, messages ch
 		case messageFromChrome := <-messages:
 			if err := chromedp.Run(taskCtx,
 				chromedp.Navigate(generatedURL),
-				triggerAutofit(cfg),
+				postNavigate(cfg),
 			); err != nil {
 				return
 			}

--- a/pkg/kiosk/local_login.go
+++ b/pkg/kiosk/local_login.go
@@ -85,6 +85,7 @@ func GrafanaKioskLocal(ctx context.Context, cfg *Config, dir string, messages ch
 				return nil
 			}),
 			chromedp.Navigate(generatedURL),
+			triggerAutofit(cfg),
 		); err != nil {
 			panic(err)
 		}
@@ -104,6 +105,7 @@ func GrafanaKioskLocal(ctx context.Context, cfg *Config, dir string, messages ch
 			chromedp.WaitVisible(`//input[@name="user"]`, chromedp.BySearch),
 			chromedp.SendKeys(`//input[@name="user"]`, cfg.Target.Username, chromedp.BySearch),
 			chromedp.SendKeys(`//input[@name="password"]`, cfg.Target.Password+kb.Enter, chromedp.BySearch),
+			triggerAutofit(cfg),
 		); err != nil {
 			panic(err)
 		}
@@ -117,6 +119,7 @@ func GrafanaKioskLocal(ctx context.Context, cfg *Config, dir string, messages ch
 		case messageFromChrome := <-messages:
 			if err := chromedp.Run(taskCtx,
 				chromedp.Navigate(generatedURL),
+				triggerAutofit(cfg),
 			); err != nil {
 				return
 			}

--- a/pkg/kiosk/utils.go
+++ b/pkg/kiosk/utils.go
@@ -1,11 +1,13 @@
 package kiosk
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/url"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/chromedp/chromedp"
 )
@@ -127,4 +129,18 @@ func generateExecutorOptions(dir string, cfg *Config) []chromedp.ExecAllocatorOp
 	}
 
 	return execAllocatorOption
+}
+
+// triggerAutofit dispatches a browser resize event after a short delay to force
+// Grafana to recalculate panel layout. Grafana 12+ does not always process the
+// autofitpanels URL parameter on initial page load.
+func triggerAutofit(cfg *Config) chromedp.ActionFunc {
+	return chromedp.ActionFunc(func(ctx context.Context) error {
+		if !cfg.General.AutoFit {
+			return nil
+		}
+		log.Printf("Sleeping %d MS before triggering autofit resize", cfg.General.PageLoadDelayMS)
+		time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
+		return chromedp.Evaluate(`window.dispatchEvent(new Event('resize'))`, nil).Do(ctx)
+	})
 }

--- a/pkg/kiosk/utils.go
+++ b/pkg/kiosk/utils.go
@@ -131,16 +131,17 @@ func generateExecutorOptions(dir string, cfg *Config) []chromedp.ExecAllocatorOp
 	return execAllocatorOption
 }
 
-// triggerAutofit dispatches a browser resize event after a short delay to force
-// Grafana to recalculate panel layout. Grafana 12+ does not always process the
-// autofitpanels URL parameter on initial page load.
+// triggerAutofit waits for the page to load, then dispatches a browser resize
+// event to force Grafana to recalculate panel layout. Grafana 12+ may not
+// process the autofitpanels URL parameter on initial page load.
 func triggerAutofit(cfg *Config) chromedp.ActionFunc {
 	return chromedp.ActionFunc(func(ctx context.Context) error {
+		log.Printf("Sleeping %d MS for page load", cfg.General.PageLoadDelayMS)
+		time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
 		if !cfg.General.AutoFit {
 			return nil
 		}
-		log.Printf("Sleeping %d MS before triggering autofit resize", cfg.General.PageLoadDelayMS)
-		time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
+		log.Println("Triggering autofit resize event")
 		return chromedp.Evaluate(`window.dispatchEvent(new Event('resize'))`, nil).Do(ctx)
 	})
 }

--- a/pkg/kiosk/utils.go
+++ b/pkg/kiosk/utils.go
@@ -161,6 +161,9 @@ func resetWindowState(cfg *Config) chromedp.ActionFunc {
 // waitForPageLoad pauses to allow the browser to finish loading.
 func waitForPageLoad(cfg *Config) chromedp.ActionFunc {
 	return chromedp.ActionFunc(func(_ context.Context) error {
+		if cfg.General.PageLoadDelayMS <= 0 {
+			return nil
+		}
 		log.Printf("Sleeping %d MS for page load", cfg.General.PageLoadDelayMS)
 		time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
 		return nil

--- a/pkg/kiosk/utils.go
+++ b/pkg/kiosk/utils.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/url"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -132,18 +133,20 @@ func generateExecutorOptions(dir string, cfg *Config) []chromedp.ExecAllocatorOp
 	return execAllocatorOption
 }
 
-// resetWindowState cycles the browser window from normal to fullscreen via
-// CDP before navigation. This forces Chrome to properly register viewport
+// cycleWindowState cycles the browser window state via CDP before navigation.
+// When no custom window size is set, it cycles normal → fullscreen.
+// When a custom window size is set, it cycles minimized → normal with the
+// specified dimensions. This forces Chrome to properly register viewport
 // dimensions so Grafana sees the correct size on initial page load.
-func resetWindowState(cfg *Config) chromedp.ActionFunc {
+func cycleWindowState(cfg *Config) chromedp.ActionFunc {
 	return chromedp.ActionFunc(func(ctx context.Context) error {
-		if cfg.General.WindowSize != "" {
-			return nil
-		}
 		log.Println("Resetting window state via CDP")
 		windowID, _, err := browser.GetWindowForTarget().Do(ctx)
 		if err != nil {
 			return fmt.Errorf("get window for target: %w", err)
+		}
+		if cfg.General.WindowSize != "" {
+			return cycleWindowToSize(windowID, cfg.General.WindowSize, ctx)
 		}
 		err = browser.SetWindowBounds(windowID, &browser.Bounds{
 			WindowState: browser.WindowStateNormal,
@@ -156,6 +159,35 @@ func resetWindowState(cfg *Config) chromedp.ActionFunc {
 			WindowState: browser.WindowStateFullscreen,
 		}).Do(ctx)
 	})
+}
+
+// cycleWindowToSize cycles the window from minimized to normal with the
+// specified dimensions to force Chrome to register the correct viewport.
+func cycleWindowToSize(windowID browser.WindowID, windowSize string, ctx context.Context) error {
+	parts := strings.SplitN(windowSize, ",", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid window-size format: %q", windowSize)
+	}
+	width, err := strconv.ParseInt(strings.TrimSpace(parts[0]), 10, 64)
+	if err != nil {
+		return fmt.Errorf("parse window width: %w", err)
+	}
+	height, err := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64)
+	if err != nil {
+		return fmt.Errorf("parse window height: %w", err)
+	}
+	err = browser.SetWindowBounds(windowID, &browser.Bounds{
+		WindowState: browser.WindowStateMinimized,
+	}).Do(ctx)
+	if err != nil {
+		return fmt.Errorf("set window minimized: %w", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	return browser.SetWindowBounds(windowID, &browser.Bounds{
+		WindowState: browser.WindowStateNormal,
+		Width:       width,
+		Height:      height,
+	}).Do(ctx)
 }
 
 // waitForPageLoad pauses to allow the browser to finish loading.

--- a/pkg/kiosk/utils.go
+++ b/pkg/kiosk/utils.go
@@ -131,10 +131,10 @@ func generateExecutorOptions(dir string, cfg *Config) []chromedp.ExecAllocatorOp
 	return execAllocatorOption
 }
 
-// triggerAutofit waits for the page to load, then dispatches a browser resize
+// postNavigate waits for the page to load, then dispatches a browser resize
 // event to force Grafana to recalculate panel layout. Grafana 12+ may not
 // process the autofitpanels URL parameter on initial page load.
-func triggerAutofit(cfg *Config) chromedp.ActionFunc {
+func postNavigate(cfg *Config) chromedp.ActionFunc {
 	return chromedp.ActionFunc(func(ctx context.Context) error {
 		log.Printf("Sleeping %d MS for page load", cfg.General.PageLoadDelayMS)
 		time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)

--- a/pkg/kiosk/utils.go
+++ b/pkg/kiosk/utils.go
@@ -116,10 +116,11 @@ func generateExecutorOptions(dir string, cfg *Config) []chromedp.ExecAllocatorOp
 			chromedp.Flag("ozone-platform", cfg.General.OzonePlatform))
 	}
 	if cfg.General.WindowSize != "" {
+		fullscreen := cfg.General.Mode == "full" || cfg.General.Mode == ""
 		execAllocatorOption = append(
 			execAllocatorOption,
-			chromedp.Flag("kiosk", false),
-			chromedp.Flag("start-fullscreen", false),
+			chromedp.Flag("kiosk", fullscreen),
+			chromedp.Flag("start-fullscreen", fullscreen),
 			// force app mode (no address bar and controls)
 			chromedp.Flag("app", "data:text/html,<title>Grafana</title>"),
 			chromedp.Flag("window-size", cfg.General.WindowSize))
@@ -161,8 +162,8 @@ func cycleWindowState(cfg *Config) chromedp.ActionFunc {
 	})
 }
 
-// cycleWindowToSize cycles the window from minimized to normal with the
-// specified dimensions to force Chrome to register the correct viewport.
+// cycleWindowToSize sets the window to the specified dimensions, then
+// cycles to fullscreen to force Chrome to register the correct viewport.
 func cycleWindowToSize(windowID browser.WindowID, windowSize string, ctx context.Context) error {
 	parts := strings.SplitN(windowSize, ",", 2)
 	if len(parts) != 2 {
@@ -177,16 +178,17 @@ func cycleWindowToSize(windowID browser.WindowID, windowSize string, ctx context
 		return fmt.Errorf("parse window height: %w", err)
 	}
 	err = browser.SetWindowBounds(windowID, &browser.Bounds{
-		WindowState: browser.WindowStateMinimized,
+		Width:  width,
+		Height: height,
 	}).Do(ctx)
 	if err != nil {
-		return fmt.Errorf("set window minimized: %w", err)
+		return fmt.Errorf("set window size: %w", err)
 	}
+
 	time.Sleep(100 * time.Millisecond)
+
 	return browser.SetWindowBounds(windowID, &browser.Bounds{
-		WindowState: browser.WindowStateNormal,
-		Width:       width,
-		Height:      height,
+		WindowState: browser.WindowStateFullscreen,
 	}).Do(ctx)
 }
 

--- a/pkg/kiosk/utils.go
+++ b/pkg/kiosk/utils.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/chromedp/cdproto/browser"
 	"github.com/chromedp/chromedp"
 )
 
@@ -131,17 +132,46 @@ func generateExecutorOptions(dir string, cfg *Config) []chromedp.ExecAllocatorOp
 	return execAllocatorOption
 }
 
-// postNavigate waits for the page to load, then dispatches a browser resize
-// event to force Grafana to recalculate panel layout. Grafana 12+ may not
-// process the autofitpanels URL parameter on initial page load.
-func postNavigate(cfg *Config) chromedp.ActionFunc {
+// resetWindowState cycles the browser window from normal to fullscreen via
+// CDP before navigation. This forces Chrome to properly register viewport
+// dimensions so Grafana sees the correct size on initial page load.
+func resetWindowState(cfg *Config) chromedp.ActionFunc {
 	return chromedp.ActionFunc(func(ctx context.Context) error {
-		log.Printf("Sleeping %d MS for page load", cfg.General.PageLoadDelayMS)
-		time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
-		if !cfg.General.AutoFit {
+		if cfg.General.WindowSize != "" {
 			return nil
 		}
-		log.Println("Triggering autofit resize event")
-		return chromedp.Evaluate(`window.dispatchEvent(new Event('resize'))`, nil).Do(ctx)
+		log.Println("Resetting window state via CDP")
+		windowID, _, err := browser.GetWindowForTarget().Do(ctx)
+		if err != nil {
+			return fmt.Errorf("get window for target: %w", err)
+		}
+		err = browser.SetWindowBounds(windowID, &browser.Bounds{
+			WindowState: browser.WindowStateNormal,
+		}).Do(ctx)
+		if err != nil {
+			return fmt.Errorf("set window normal: %w", err)
+		}
+		time.Sleep(100 * time.Millisecond)
+		return browser.SetWindowBounds(windowID, &browser.Bounds{
+			WindowState: browser.WindowStateFullscreen,
+		}).Do(ctx)
 	})
+}
+
+// waitForPageLoad pauses to allow the browser to finish loading.
+func waitForPageLoad(cfg *Config) chromedp.ActionFunc {
+	return chromedp.ActionFunc(func(_ context.Context) error {
+		log.Printf("Sleeping %d MS for page load", cfg.General.PageLoadDelayMS)
+		time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
+		return nil
+	})
+}
+
+// waitForBrowserStartup pauses to allow the browser process to become idle.
+func waitForBrowserStartup(cfg *Config) {
+	if cfg.General.PageLoadDelayMS <= 0 {
+		return
+	}
+	log.Printf("Sleeping %d MS waiting for browser startup", cfg.General.PageLoadDelayMS)
+	time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
 }

--- a/pkg/kiosk/utils.go
+++ b/pkg/kiosk/utils.go
@@ -140,7 +140,7 @@ func generateExecutorOptions(dir string, cfg *Config) []chromedp.ExecAllocatorOp
 // dimensions so Grafana sees the correct size on initial page load.
 func cycleWindowState(cfg *Config) chromedp.ActionFunc {
 	return chromedp.ActionFunc(func(ctx context.Context) error {
-		log.Println("Resetting window state via CDP")
+		log.Println("Cycling window state via CDP")
 		windowID, _, err := browser.GetWindowForTarget().Do(ctx)
 		if err != nil {
 			return fmt.Errorf("get window for target: %w", err)

--- a/pkg/kiosk/utils_test.go
+++ b/pkg/kiosk/utils_test.go
@@ -208,12 +208,12 @@ func TestGenerateExecutorOptions(t *testing.T) {
 			opts := generateExecutorOptions("/tmp/test", cfg)
 			flags := applyOptions(opts)
 
-			Convey("Should override kiosk to false", func() {
-				So(flags["kiosk"], ShouldEqual, false)
+			Convey("Should keep kiosk as true", func() {
+				So(flags["kiosk"], ShouldEqual, true)
 			})
 
-			Convey("Should override start-fullscreen to false", func() {
-				So(flags["start-fullscreen"], ShouldEqual, false)
+			Convey("Should keep start-fullscreen as true", func() {
+				So(flags["start-fullscreen"], ShouldEqual, true)
 			})
 
 			Convey("Should set app mode", func() {
@@ -221,6 +221,31 @@ func TestGenerateExecutorOptions(t *testing.T) {
 			})
 
 			Convey("Should set window-size flag", func() {
+				So(flags["window-size"], ShouldEqual, "1920,1080")
+			})
+		})
+
+		Convey("When window size is set with tv mode", func() {
+			cfg := &Config{
+				BuildInfo: BuildInfo{Version: "v1.0.0"},
+				General: General{
+					WindowSize:     "1920,1080",
+					WindowPosition: "0,0",
+					Mode:           "tv",
+				},
+			}
+			opts := generateExecutorOptions("/tmp/test", cfg)
+			flags := applyOptions(opts)
+
+			Convey("Should set kiosk to false", func() {
+				So(flags["kiosk"], ShouldEqual, false)
+			})
+
+			Convey("Should set start-fullscreen to false", func() {
+				So(flags["start-fullscreen"], ShouldEqual, false)
+			})
+
+			Convey("Should still set window-size flag", func() {
 				So(flags["window-size"], ShouldEqual, "1920,1080")
 			})
 		})
@@ -384,9 +409,9 @@ func TestGenerateExecutorOptions(t *testing.T) {
 				So(flags["ozone-platform"], ShouldEqual, "x11")
 			})
 
-			Convey("Should override kiosk and fullscreen for window size", func() {
-				So(flags["kiosk"], ShouldEqual, false)
-				So(flags["start-fullscreen"], ShouldEqual, false)
+			Convey("Should keep kiosk and fullscreen for window size", func() {
+				So(flags["kiosk"], ShouldEqual, true)
+				So(flags["start-fullscreen"], ShouldEqual, true)
 				So(flags["app"], ShouldEqual, "data:text/html,<title>Grafana</title>")
 				So(flags["window-size"], ShouldEqual, "800,600")
 			})

--- a/pkg/kiosk/utils_test.go
+++ b/pkg/kiosk/utils_test.go
@@ -494,17 +494,32 @@ func TestGenerateExecutorOptions(t *testing.T) {
 	})
 }
 
-func TestResetWindowState(t *testing.T) {
-	Convey("Given resetWindowState", t, func() {
-		Convey("When custom window size is set", func() {
-			cfg := &Config{
-				General: General{WindowSize: "1920,1080"},
-			}
-			action := resetWindowState(cfg)
-			err := action.Do(context.Background())
+func TestCycleWindowToSize(t *testing.T) {
+	Convey("Given cycleWindowToSize", t, func() {
+		Convey("When window size format is invalid", func() {
+			err := cycleWindowToSize(0, "invalid", context.Background())
 
-			Convey("Should skip and return nil", func() {
-				So(err, ShouldBeNil)
+			Convey("Should return a format error", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "invalid window-size format")
+			})
+		})
+
+		Convey("When width is not a number", func() {
+			err := cycleWindowToSize(0, "abc,1080", context.Background())
+
+			Convey("Should return a width parse error", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "parse window width")
+			})
+		})
+
+		Convey("When height is not a number", func() {
+			err := cycleWindowToSize(0, "1920,abc", context.Background())
+
+			Convey("Should return a height parse error", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldContainSubstring, "parse window height")
 			})
 		})
 	})

--- a/pkg/kiosk/utils_test.go
+++ b/pkg/kiosk/utils_test.go
@@ -1,11 +1,13 @@
 package kiosk
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 	"unsafe"
 
 	"github.com/chromedp/chromedp"
@@ -488,6 +490,102 @@ func TestGenerateExecutorOptions(t *testing.T) {
 			Convey("Should not disable HttpsUpgrades feature", func() {
 				So(flags["disable-features"], ShouldEqual, "Translate")
 			})
+		})
+	})
+}
+
+func TestResetWindowState(t *testing.T) {
+	Convey("Given resetWindowState", t, func() {
+		Convey("When custom window size is set", func() {
+			cfg := &Config{
+				General: General{WindowSize: "1920,1080"},
+			}
+			action := resetWindowState(cfg)
+			err := action.Do(context.Background())
+
+			Convey("Should skip and return nil", func() {
+				So(err, ShouldBeNil)
+			})
+		})
+	})
+}
+
+func TestWaitForPageLoad(t *testing.T) {
+	Convey("Given waitForPageLoad", t, func() {
+		Convey("When PageLoadDelayMS is zero", func() {
+			cfg := &Config{
+				General: General{PageLoadDelayMS: 0},
+			}
+			action := waitForPageLoad(cfg)
+			start := time.Now()
+			err := action.Do(context.Background())
+			elapsed := time.Since(start)
+
+			So(err, ShouldBeNil)
+			So(elapsed, ShouldBeLessThan, 50*time.Millisecond)
+		})
+
+		Convey("When PageLoadDelayMS is negative", func() {
+			cfg := &Config{
+				General: General{PageLoadDelayMS: -100},
+			}
+			action := waitForPageLoad(cfg)
+			start := time.Now()
+			err := action.Do(context.Background())
+			elapsed := time.Since(start)
+
+			So(err, ShouldBeNil)
+			So(elapsed, ShouldBeLessThan, 50*time.Millisecond)
+		})
+
+		Convey("When PageLoadDelayMS is positive", func() {
+			cfg := &Config{
+				General: General{PageLoadDelayMS: 100},
+			}
+			action := waitForPageLoad(cfg)
+			start := time.Now()
+			err := action.Do(context.Background())
+			elapsed := time.Since(start)
+
+			So(err, ShouldBeNil)
+			So(elapsed, ShouldBeGreaterThanOrEqualTo, 100*time.Millisecond)
+		})
+	})
+}
+
+func TestWaitForBrowserStartup(t *testing.T) {
+	Convey("Given waitForBrowserStartup", t, func() {
+		Convey("When PageLoadDelayMS is zero", func() {
+			cfg := &Config{
+				General: General{PageLoadDelayMS: 0},
+			}
+			start := time.Now()
+			waitForBrowserStartup(cfg)
+			elapsed := time.Since(start)
+
+			So(elapsed, ShouldBeLessThan, 50*time.Millisecond)
+		})
+
+		Convey("When PageLoadDelayMS is negative", func() {
+			cfg := &Config{
+				General: General{PageLoadDelayMS: -100},
+			}
+			start := time.Now()
+			waitForBrowserStartup(cfg)
+			elapsed := time.Since(start)
+
+			So(elapsed, ShouldBeLessThan, 50*time.Millisecond)
+		})
+
+		Convey("When PageLoadDelayMS is positive", func() {
+			cfg := &Config{
+				General: General{PageLoadDelayMS: 100},
+			}
+			start := time.Now()
+			waitForBrowserStartup(cfg)
+			elapsed := time.Since(start)
+
+			So(elapsed, ShouldBeGreaterThanOrEqualTo, 100*time.Millisecond)
 		})
 	})
 }


### PR DESCRIPTION
## Summary

### Bug Fixes

- Fix Grafana 12+ scenes viewport changes causing kiosk to not autofit panels ([#177](https://github.com/grafana/grafana-kiosk/issues/177))
- Use CDP `browser.SetWindowBounds` to cycle the window state before navigation, forcing Chrome to properly register viewport dimensions
- When no custom window size: cycles normal → fullscreen
- When custom `--window-size`: sets dimensions then cycles to fullscreen via CDP
- Applied `cycleWindowState` before the first `chromedp.Navigate` in all 8 login handlers
- Respect kiosk mode when `--window-size` is set: `full` mode enables kiosk/fullscreen flags, `tv`/`disabled` disables them
- Restore post-navigate sleeps in anonymous and apikey login handlers
- Restore second pre-navigate sleep in AWS login handler
- Restore hardcoded 3s sleep for gcom login redirect
- Add `PageLoadDelayMS <= 0` guard to `waitForPageLoad` for consistency

### Refactors

- Extract `waitForBrowserStartup` utility — plain function, pauses after browser process start, guarded by `PageLoadDelayMS > 0`
- Extract `waitForPageLoad` utility — chromedp ActionFunc for delays within navigation chains, guarded by `PageLoadDelayMS > 0`
- Extract `cycleWindowToSize` helper — parses `width,height` string, sets dimensions, then cycles to fullscreen
- Replace inline `time.Sleep` calls with the appropriate utility function
- Remove `postNavigate` (resize event dispatch) — replaced by pre-navigation window state cycle

### Tests

- Add tests for `cycleWindowToSize`, `waitForPageLoad`, and `waitForBrowserStartup` utilities
- Add test for window-size with tv mode (kiosk/fullscreen flags disabled)

### Documentation

- Add "Window size and kiosk mode" section to README with behavior matrix table

### Chores

- Categorize CHANGELOG unreleased section with headings (Features, Bug Fixes, Tests, CI/CD, Dependencies, Chores)
- Add changelog and PR summary category ordering rule to AGENTS.md
- Standardize issue links to full markdown format in CHANGELOG
- Move misplaced entries to correct changelog categories

Fixes #177

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run --timeout 5m ./pkg/...` — 0 issues
- [x] Manual: test with Grafana 12+ and verify panels auto-fit on initial page load
- [x] Manual: test with `--window-size` flag and verify window cycles to fullscreen via CDP
- [x] Manual: test with playlists and verify panels auto-fit on each dashboard transition
- [ ] Manual: test with `--window-size` and `-kiosk-mode=tv` to verify no fullscreen
<!-- octocov -->
## Code Metrics Report
| Coverage | Code to Test Ratio | Test Execution Time |
|---------:|-------------------:|--------------------:|
| 25.5%    | 1:0.7              | 3m22s               |


### Code coverage of files in pull request scope (21.3%)

|                                                                                     Files                                                                                     | Coverage |
|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|
| [pkg/kiosk/anonymous_login.go](https://github.com/grafana/grafana-kiosk/blob/d02b3fe93a0439e6118d75faba0eb50ce0755466/pkg%2Fkiosk%2Fanonymous_login.go)                       | 0.0%     |
| [pkg/kiosk/apikey_login.go](https://github.com/grafana/grafana-kiosk/blob/d02b3fe93a0439e6118d75faba0eb50ce0755466/pkg%2Fkiosk%2Fapikey_login.go)                             | 16.6%    |
| [pkg/kiosk/aws_login.go](https://github.com/grafana/grafana-kiosk/blob/d02b3fe93a0439e6118d75faba0eb50ce0755466/pkg%2Fkiosk%2Faws_login.go)                                   | 0.0%     |
| [pkg/kiosk/azuread_login.go](https://github.com/grafana/grafana-kiosk/blob/d02b3fe93a0439e6118d75faba0eb50ce0755466/pkg%2Fkiosk%2Fazuread_login.go)                           | 0.0%     |
| [pkg/kiosk/grafana_com_login.go](https://github.com/grafana/grafana-kiosk/blob/d02b3fe93a0439e6118d75faba0eb50ce0755466/pkg%2Fkiosk%2Fgrafana_com_login.go)                   | 0.0%     |
| [pkg/kiosk/grafana_genericoauth_login.go](https://github.com/grafana/grafana-kiosk/blob/d02b3fe93a0439e6118d75faba0eb50ce0755466/pkg%2Fkiosk%2Fgrafana_genericoauth_login.go) | 0.0%     |
| [pkg/kiosk/grafana_idtoken_login.go](https://github.com/grafana/grafana-kiosk/blob/d02b3fe93a0439e6118d75faba0eb50ce0755466/pkg%2Fkiosk%2Fgrafana_idtoken_login.go)           | 0.0%     |
| [pkg/kiosk/local_login.go](https://github.com/grafana/grafana-kiosk/blob/d02b3fe93a0439e6118d75faba0eb50ce0755466/pkg%2Fkiosk%2Flocal_login.go)                               | 15.2%    |
| [pkg/kiosk/utils.go](https://github.com/grafana/grafana-kiosk/blob/d02b3fe93a0439e6118d75faba0eb50ce0755466/pkg%2Fkiosk%2Futils.go)                                           | 77.9%    |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
