### PR TITLE
fix: query errors with newer Grafana API

### DIFF
--- a/pkg/kiosk/apikey_login.go
+++ b/pkg/kiosk/apikey_login.go
@@ -30,7 +30,8 @@ func IsDataSourceQueryRequest(requestURL, targetScheme, targetHost string) bool 
 		return true
 	}
 
-	return strings.Contains(rest, "/apis/query.grafana.app/") && strings.Contains(rest, "/query")
+	path := strings.SplitN(rest, "?", 2)[0]
+	return strings.Contains(rest, "/apis/query.grafana.app/") && strings.HasSuffix(path, "/query")
 }
 
 // IsTargetHostRequest checks if the request URL host matches the target host.

--- a/pkg/kiosk/apikey_login.go
+++ b/pkg/kiosk/apikey_login.go
@@ -12,7 +12,8 @@ import (
 )
 
 // IsDataSourceQueryRequest checks if the request URL is a datasource query API
-// call to the target host, matching scheme://host and /api/ds/query? path.
+// call to the target host. It matches both the legacy /api/ds/query path and
+// the newer /apis/query.grafana.app/.../query path.
 func IsDataSourceQueryRequest(requestURL, targetScheme, targetHost string) bool {
 	prefix := targetScheme + "://" + targetHost
 	if !strings.HasPrefix(requestURL, prefix) {
@@ -25,7 +26,11 @@ func IsDataSourceQueryRequest(requestURL, targetScheme, targetHost string) bool 
 		return false
 	}
 
-	return strings.Contains(requestURL, "/api/ds/query?")
+	if strings.Contains(requestURL, "/api/ds/query?") {
+		return true
+	}
+
+	return strings.Contains(rest, "/apis/query.grafana.app/") && strings.Contains(rest, "/query")
 }
 
 // IsTargetHostRequest checks if the request URL host matches the target host.

--- a/pkg/kiosk/apikey_login_test.go
+++ b/pkg/kiosk/apikey_login_test.go
@@ -87,6 +87,14 @@ func TestIsDataSourceQueryRequest(t *testing.T) {
 			)
 			So(result, ShouldBeFalse)
 		})
+
+		Convey("When request is under query.grafana.app but not a /query endpoint", func() {
+			result := IsDataSourceQueryRequest(
+				"https://myorg.grafana.net/apis/query.grafana.app/v0alpha1/namespaces/stacks-123/something-else",
+				"https", "myorg.grafana.net",
+			)
+			So(result, ShouldBeFalse)
+		})
 	})
 }
 

--- a/pkg/kiosk/apikey_login_test.go
+++ b/pkg/kiosk/apikey_login_test.go
@@ -55,6 +55,38 @@ func TestIsDataSourceQueryRequest(t *testing.T) {
 			)
 			So(result, ShouldBeFalse)
 		})
+
+		Convey("When request uses the Grafana Cloud query API path", func() {
+			result := IsDataSourceQueryRequest(
+				"https://myorg.grafana.net/apis/query.grafana.app/v0alpha1/namespaces/stacks-123/query?ds_type=prometheus&requestId=SQR1",
+				"https", "myorg.grafana.net",
+			)
+			So(result, ShouldBeTrue)
+		})
+
+		Convey("When request uses the Grafana Cloud query API path with port", func() {
+			result := IsDataSourceQueryRequest(
+				"https://localhost:3000/apis/query.grafana.app/v0alpha1/namespaces/default/query?ds_type=loki",
+				"https", "localhost:3000",
+			)
+			So(result, ShouldBeTrue)
+		})
+
+		Convey("When request uses Grafana Cloud API path but wrong host", func() {
+			result := IsDataSourceQueryRequest(
+				"https://other.grafana.net/apis/query.grafana.app/v0alpha1/namespaces/stacks-123/query?ds_type=prometheus",
+				"https", "myorg.grafana.net",
+			)
+			So(result, ShouldBeFalse)
+		})
+
+		Convey("When request has /apis/ path but is not a query endpoint", func() {
+			result := IsDataSourceQueryRequest(
+				"https://grafana.example.com/apis/dashboard.grafana.app/v1/namespaces/default/dashboards",
+				"https", "grafana.example.com",
+			)
+			So(result, ShouldBeFalse)
+		})
 	})
 }
 


### PR DESCRIPTION
Closes #253

## Bug Fixes

Extend `IsDataSourceQueryRequest` to match both the legacy `/api/ds/query?` path and the newer
  `/apis/query.grafana.app/<version>/namespaces/<ns>/query` path used by Grafana Cloud

## Tests

Add test cases for query API path matching (correct host, with port, wrong host, non-query API path)

## Details

When using `login-method=apikey`, the kiosk intercepts browser requests via the Chrome DevTools Protocol `fetch` domain
to inject `Authorization` and `Content-Type` headers. The `Authorization: Bearer` header was added to all requests
matching the target host, but the `Content-Type: application/json` header was only added when the request URL contained `/api/ds/query?` — the legacy Grafana datasource query path.

Grafana Cloud now routes datasource queries through a Kubernetes-style API:
/apis/query.grafana.app/v0alpha1/namespaces/stacks-/query?ds_type=prometheus&requestId=...

Without the `Content-Type` header, the server cannot parse the POST body and returns a `400 Bad Request`.
