### PR TITLE
fix: correct hideLogo query param and improve config summary logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,12 @@ and this project adheres to
 - Add `-hide-logo` flag to hide Powered by Grafana logo ([#240](https://github.com/grafana/grafana-kiosk/issues/240))
 - Add `-hide-playlist-nav` flag to hide playlist navigation controls ([#240](https://github.com/grafana/grafana-kiosk/issues/240))
 - Update `_dash.hideLinks`, `_dash.hideTimePicker`, `_dash.hideVariables` query param values to match Grafana's native format
+- Add hide flags to startup config summary logging with visual section separators
+- Refactor `summary()` into `logGeneralSettings`, `logTargetSettings`, `logGoAuthSettings`
 
 ### Bug Fixes
 
+- Fix `hideLogo` query parameter from `_dash.hideLogo` to `hideLogo` to match Grafana's native format
 - Fix Grafana 12+ scenes viewport changes causing kiosk to not autofit panels ([#177](https://github.com/grafana/grafana-kiosk/issues/177))
 - Fix `cycleWindowToSize` unconditionally cycling to fullscreen when kiosk mode is `tv` or `disabled` ([#177](https://github.com/grafana/grafana-kiosk/issues/177))
 - Fix HTTP URLs blocked by Chromium 130+ HTTPS-First Mode ([#155](https://github.com/grafana/grafana-kiosk/issues/155))

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ These flags append `_dash.*` query parameters to hide specific UI elements:
 | Flag                 | Query parameter              | UI effect                         |
 | -------------------- | ---------------------------- | --------------------------------- |
 | `-hide-links`        | `_dash.hideLinks=true`       | Hide links in the top nav bar     |
-| `-hide-logo`         | `_dash.hideLogo=1`           | Hide Powered by Grafana logo      |
+| `-hide-logo`         | `hideLogo=1`                 | Hide Powered by Grafana logo      |
 | `-hide-playlist-nav` | `_dash.hidePlaylistNav=true` | Hide playlist navigation controls |
 | `-hide-time-picker`  | `_dash.hideTimePicker=true`  | Hide time picker in the top nav   |
 | `-hide-variables`    | `_dash.hideVariables=true`   | Hide variables in the top nav     |

--- a/pkg/cmd/grafana-kiosk/main.go
+++ b/pkg/cmd/grafana-kiosk/main.go
@@ -211,7 +211,12 @@ func setEnvironment() {
 }
 
 func summary(cfg *kiosk.Config) {
-	// general
+	logGeneralSettings(cfg)
+	logTargetSettings(cfg)
+	logGoAuthSettings(cfg)
+}
+
+func logGeneralSettings(cfg *kiosk.Config) {
 	log.Println("AutoFit:", cfg.General.AutoFit)
 	log.Println("LXDEEnabled:", cfg.General.LXDEEnabled)
 	log.Println("LXDEHome:", cfg.General.LXDEHome)
@@ -221,7 +226,14 @@ func summary(cfg *kiosk.Config) {
 	log.Println("WindowSize:", cfg.General.WindowSize)
 	log.Println("ScaleFactor:", cfg.General.ScaleFactor)
 	log.Println("PageLoadDelayMS:", cfg.General.PageLoadDelayMS)
-	// target
+	log.Println("HideLinks:", cfg.General.HideLinks)
+	log.Println("HideLogo:", cfg.General.HideLogo)
+	log.Println("HidePlaylistNav:", cfg.General.HidePlaylistNav)
+	log.Println("HideTimePicker:", cfg.General.HideTimePicker)
+	log.Println("HideVariables:", cfg.General.HideVariables)
+}
+
+func logTargetSettings(cfg *kiosk.Config) {
 	log.Println("URL:", cfg.Target.URL)
 	log.Println("LoginMethod:", cfg.Target.LoginMethod)
 	log.Println("Username:", cfg.Target.Username)
@@ -229,7 +241,9 @@ func summary(cfg *kiosk.Config) {
 	log.Println("IgnoreCertificateErrors:", cfg.Target.IgnoreCertificateErrors)
 	log.Println("IsPlayList:", cfg.Target.IsPlayList)
 	log.Println("UseMFA:", cfg.Target.UseMFA)
-	// goauth
+}
+
+func logGoAuthSettings(cfg *kiosk.Config) {
 	log.Println("Fieldname AutoLogin:", cfg.GoAuth.AutoLogin)
 	log.Println("Fieldname Username:", cfg.GoAuth.UsernameField)
 	log.Println("Fieldname Password:", cfg.GoAuth.PasswordField)

--- a/pkg/cmd/grafana-kiosk/main.go
+++ b/pkg/cmd/grafana-kiosk/main.go
@@ -211,11 +211,11 @@ func setEnvironment() {
 }
 
 func summary(cfg *kiosk.Config) {
-	log.Println("*********************************************************")
+	log.Println("*************************************************************")
 	logGeneralSettings(cfg)
 	logTargetSettings(cfg)
 	logGoAuthSettings(cfg)
-	log.Println("*********************************************************")
+	log.Println("*************************************************************")
 }
 
 func logGeneralSettings(cfg *kiosk.Config) {

--- a/pkg/cmd/grafana-kiosk/main.go
+++ b/pkg/cmd/grafana-kiosk/main.go
@@ -211,15 +211,15 @@ func setEnvironment() {
 }
 
 func summary(cfg *kiosk.Config) {
-	log.Println("****** Configuration ******")
+	log.Println("*********************************************************")
 	logGeneralSettings(cfg)
 	logTargetSettings(cfg)
 	logGoAuthSettings(cfg)
-	log.Println("***************************")
+	log.Println("*********************************************************")
 }
 
 func logGeneralSettings(cfg *kiosk.Config) {
-	log.Println("--- General ---")
+	log.Println("--- General -------------------------------------------------")
 	log.Println("AutoFit:", cfg.General.AutoFit)
 	log.Println("LXDEEnabled:", cfg.General.LXDEEnabled)
 	log.Println("LXDEHome:", cfg.General.LXDEHome)
@@ -237,7 +237,7 @@ func logGeneralSettings(cfg *kiosk.Config) {
 }
 
 func logTargetSettings(cfg *kiosk.Config) {
-	log.Println("--- Target ---")
+	log.Println("--- Target --------------------------------------------------")
 	log.Println("URL:", cfg.Target.URL)
 	log.Println("LoginMethod:", cfg.Target.LoginMethod)
 	log.Println("Username:", cfg.Target.Username)
@@ -248,7 +248,7 @@ func logTargetSettings(cfg *kiosk.Config) {
 }
 
 func logGoAuthSettings(cfg *kiosk.Config) {
-	log.Println("--- GoAuth ---")
+	log.Println("--- GoAuth --------------------------------------------------")
 	log.Println("Fieldname AutoLogin:", cfg.GoAuth.AutoLogin)
 	log.Println("Fieldname Username:", cfg.GoAuth.UsernameField)
 	log.Println("Fieldname Password:", cfg.GoAuth.PasswordField)

--- a/pkg/cmd/grafana-kiosk/main.go
+++ b/pkg/cmd/grafana-kiosk/main.go
@@ -211,12 +211,15 @@ func setEnvironment() {
 }
 
 func summary(cfg *kiosk.Config) {
+	log.Println("****** Configuration ******")
 	logGeneralSettings(cfg)
 	logTargetSettings(cfg)
 	logGoAuthSettings(cfg)
+	log.Println("***************************")
 }
 
 func logGeneralSettings(cfg *kiosk.Config) {
+	log.Println("--- General ---")
 	log.Println("AutoFit:", cfg.General.AutoFit)
 	log.Println("LXDEEnabled:", cfg.General.LXDEEnabled)
 	log.Println("LXDEHome:", cfg.General.LXDEHome)
@@ -234,6 +237,7 @@ func logGeneralSettings(cfg *kiosk.Config) {
 }
 
 func logTargetSettings(cfg *kiosk.Config) {
+	log.Println("--- Target ---")
 	log.Println("URL:", cfg.Target.URL)
 	log.Println("LoginMethod:", cfg.Target.LoginMethod)
 	log.Println("Username:", cfg.Target.Username)
@@ -244,6 +248,7 @@ func logTargetSettings(cfg *kiosk.Config) {
 }
 
 func logGoAuthSettings(cfg *kiosk.Config) {
+	log.Println("--- GoAuth ---")
 	log.Println("Fieldname AutoLogin:", cfg.GoAuth.AutoLogin)
 	log.Println("Fieldname Username:", cfg.GoAuth.UsernameField)
 	log.Println("Fieldname Password:", cfg.GoAuth.PasswordField)

--- a/pkg/cmd/grafana-kiosk/main_test.go
+++ b/pkg/cmd/grafana-kiosk/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"log"
 	"os"
 	"testing"
@@ -494,6 +495,96 @@ func TestMain(t *testing.T) {
 			So(result.LoginMethod, ShouldEqual, "local")
 			So(result.URL, ShouldEqual, "https://play.grafana.org")
 			So(result.AutoFit, ShouldBeTrue)
+		})
+	})
+}
+
+// captureLogOutput redirects log output to a buffer for the duration of fn.
+func captureLogOutput(fn func()) string {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+	fn()
+	return buf.String()
+}
+
+func TestLogGeneralSettings(t *testing.T) {
+	Convey("Given a config with general settings", t, func() {
+		cfg := &kiosk.Config{
+			General: kiosk.General{
+				AutoFit:         true,
+				Mode:            "full",
+				Incognito:       true,
+				WindowPosition:  "0,0",
+				WindowSize:      "1920,1080",
+				ScaleFactor:     "1.5",
+				PageLoadDelayMS: 3000,
+				HideLinks:       true,
+				HideLogo:        true,
+				HidePlaylistNav: true,
+				HideTimePicker:  true,
+				HideVariables:   true,
+			},
+		}
+
+		Convey("Should log all general fields", func() {
+			output := captureLogOutput(func() { logGeneralSettings(cfg) })
+			So(output, ShouldContainSubstring, "AutoFit: true")
+			So(output, ShouldContainSubstring, "Mode: full")
+			So(output, ShouldContainSubstring, "Incognito: true")
+			So(output, ShouldContainSubstring, "WindowSize: 1920,1080")
+			So(output, ShouldContainSubstring, "ScaleFactor: 1.5")
+			So(output, ShouldContainSubstring, "PageLoadDelayMS: 3000")
+			So(output, ShouldContainSubstring, "HideLinks: true")
+			So(output, ShouldContainSubstring, "HideLogo: true")
+			So(output, ShouldContainSubstring, "HidePlaylistNav: true")
+			So(output, ShouldContainSubstring, "HideTimePicker: true")
+			So(output, ShouldContainSubstring, "HideVariables: true")
+		})
+	})
+}
+
+func TestLogTargetSettings(t *testing.T) {
+	Convey("Given a config with target settings", t, func() {
+		cfg := &kiosk.Config{
+			Target: kiosk.Target{
+				URL:         "https://grafana.example.com",
+				LoginMethod: "local",
+				Username:    "admin",
+				Password:    "supersecret",
+				IsPlayList:  true,
+				UseMFA:      true,
+			},
+		}
+
+		Convey("Should log target fields and redact password", func() {
+			output := captureLogOutput(func() { logTargetSettings(cfg) })
+			So(output, ShouldContainSubstring, "URL: https://grafana.example.com")
+			So(output, ShouldContainSubstring, "LoginMethod: local")
+			So(output, ShouldContainSubstring, "Username: admin")
+			So(output, ShouldContainSubstring, "Password: *redacted*")
+			So(output, ShouldNotContainSubstring, "supersecret")
+			So(output, ShouldContainSubstring, "IsPlayList: true")
+			So(output, ShouldContainSubstring, "UseMFA: true")
+		})
+	})
+}
+
+func TestLogGoAuthSettings(t *testing.T) {
+	Convey("Given a config with GoAuth settings", t, func() {
+		cfg := &kiosk.Config{
+			GoAuth: kiosk.GoAuth{
+				AutoLogin:     true,
+				UsernameField: "email",
+				PasswordField: "passwd",
+			},
+		}
+
+		Convey("Should log GoAuth fields", func() {
+			output := captureLogOutput(func() { logGoAuthSettings(cfg) })
+			So(output, ShouldContainSubstring, "Fieldname AutoLogin: true")
+			So(output, ShouldContainSubstring, "Fieldname Username: email")
+			So(output, ShouldContainSubstring, "Fieldname Password: passwd")
 		})
 	})
 }

--- a/pkg/cmd/grafana-kiosk/main_test.go
+++ b/pkg/cmd/grafana-kiosk/main_test.go
@@ -529,6 +529,7 @@ func TestLogGeneralSettings(t *testing.T) {
 
 		Convey("Should log all general fields", func() {
 			output := captureLogOutput(func() { logGeneralSettings(cfg) })
+			So(output, ShouldContainSubstring, "--- General ---")
 			So(output, ShouldContainSubstring, "AutoFit: true")
 			So(output, ShouldContainSubstring, "Mode: full")
 			So(output, ShouldContainSubstring, "Incognito: true")
@@ -559,6 +560,7 @@ func TestLogTargetSettings(t *testing.T) {
 
 		Convey("Should log target fields and redact password", func() {
 			output := captureLogOutput(func() { logTargetSettings(cfg) })
+			So(output, ShouldContainSubstring, "--- Target ---")
 			So(output, ShouldContainSubstring, "URL: https://grafana.example.com")
 			So(output, ShouldContainSubstring, "LoginMethod: local")
 			So(output, ShouldContainSubstring, "Username: admin")
@@ -582,6 +584,7 @@ func TestLogGoAuthSettings(t *testing.T) {
 
 		Convey("Should log GoAuth fields", func() {
 			output := captureLogOutput(func() { logGoAuthSettings(cfg) })
+			So(output, ShouldContainSubstring, "--- GoAuth ---")
 			So(output, ShouldContainSubstring, "Fieldname AutoLogin: true")
 			So(output, ShouldContainSubstring, "Fieldname Username: email")
 			So(output, ShouldContainSubstring, "Fieldname Password: passwd")

--- a/pkg/cmd/grafana-kiosk/main_test.go
+++ b/pkg/cmd/grafana-kiosk/main_test.go
@@ -529,7 +529,7 @@ func TestLogGeneralSettings(t *testing.T) {
 
 		Convey("Should log all general fields", func() {
 			output := captureLogOutput(func() { logGeneralSettings(cfg) })
-			So(output, ShouldContainSubstring, "--- General ---")
+			So(output, ShouldContainSubstring, "--- General ----")
 			So(output, ShouldContainSubstring, "AutoFit: true")
 			So(output, ShouldContainSubstring, "Mode: full")
 			So(output, ShouldContainSubstring, "Incognito: true")

--- a/pkg/kiosk/utils.go
+++ b/pkg/kiosk/utils.go
@@ -36,7 +36,7 @@ func GenerateURL(cfg *Config) string {
 		parsedQuery.Set("_dash.hideLinks", "true")
 	}
 	if cfg.General.HideLogo {
-		parsedQuery.Set("_dash.hideLogo", "1") // Grafana uses "1" for this param, not "true"
+		parsedQuery.Set("hideLogo", "1")
 	}
 	if cfg.General.HidePlaylistNav {
 		parsedQuery.Set("_dash.hidePlaylistNav", "true")

--- a/pkg/kiosk/utils_test.go
+++ b/pkg/kiosk/utils_test.go
@@ -67,7 +67,7 @@ func TestGenerateURL(t *testing.T) {
 			conf.General.Mode = "full"
 			conf.General.HideLogo = true
 			anURL := GenerateURL(&conf)
-			So(anURL, ShouldEqual, "https://play.grafana.org?_dash.hideLogo=1&kiosk=1&autofitpanels")
+			So(anURL, ShouldEqual, "https://play.grafana.org?hideLogo=1&kiosk=1&autofitpanels")
 		})
 		Convey("Hide playlist nav appends hidePlaylistNav parameter", func() {
 			conf := GetConfig()


### PR DESCRIPTION
## Summary

### Bug Fixes

- Fix `hideLogo` query parameter from `_dash.hideLogo` to `hideLogo` to match Grafana's native format
- Update README table to reflect correct query parameter

### Features

- Add all hide flags (`HideLinks`, `HideLogo`, `HidePlaylistNav`, `HideTimePicker`, `HideVariables`) to startup config summary logging
- Refactor `summary()` into `logGeneralSettings`, `logTargetSettings`, `logGoAuthSettings` sub-functions
- Add visual separators (`****** Configuration ******` header/footer, `--- Section ---` headers) to config summary output

### Tests

- Add unit tests for `logGeneralSettings` (11 assertions), `logTargetSettings` (8 assertions including password redaction), `logGoAuthSettings` (4 assertions)
- Verify password is never logged in plaintext

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `npx markdownlint-cli2 CHANGELOG.md README.md` — 0 errors
- [x] Password redaction verified in `TestLogTargetSettings`
<!-- octocov -->
## Code Metrics Report
| Coverage | Code to Test Ratio | Test Execution Time |
|---------:|-------------------:|--------------------:|
| 33.7%    | 1:0.9              | 3m12s               |


### Code coverage of files in pull request scope (61.8%)

|                                                                            Files                                                                            | Coverage |
|-------------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|
| [pkg/cmd/grafana-kiosk/main.go](https://github.com/grafana/grafana-kiosk/blob/c405ae5d5cd61cc7fb80b16096bc59fca9f3aae3/pkg%2Fcmd%2Fgrafana-kiosk%2Fmain.go) | 54.4%    |
| [pkg/kiosk/utils.go](https://github.com/grafana/grafana-kiosk/blob/c405ae5d5cd61cc7fb80b16096bc59fca9f3aae3/pkg%2Fkiosk%2Futils.go)                         | 77.9%    |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
