### PR TITLE
feat: add -browser and -browser-path flags for Chrome/Edge selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to
 
 ### Features
 
+- Add `-browser` flag (env `KIOSK_BROWSER`, default `chrome`) to choose between Chrome and Microsoft Edge as the launched browser
+- Add `-browser-path` flag (env `KIOSK_BROWSER_PATH`) to point at an explicit Chromium-based browser executable; overrides `-browser`
 - Add `--incognito` flag to optionally disable Chrome incognito mode ([#127](https://github.com/grafana/grafana-kiosk/issues/127))
 - Add `-hide-logo` flag to hide Powered by Grafana logo ([#240](https://github.com/grafana/grafana-kiosk/issues/240))
 - Add `-hide-playlist-nav` flag to hide playlist navigation controls ([#240](https://github.com/grafana/grafana-kiosk/issues/240))
@@ -30,6 +32,7 @@ and this project adheres to
 
 ### Tests
 
+- Add tests for `resolveBrowserExecPath` covering chrome default, custom path override, edge PATH lookup, and unknown browsers
 - Add tests for `IsDataSourceQueryRequest` and `IsTargetHostRequest` in apikey login
 - Add tests for `sanitize` in main and initialize packages
 - Add tests for `GenerateURL` playlist mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ and this project adheres to
 
 ### Features
 
-- Add `-browser` flag (env `KIOSK_BROWSER`, default `chrome`) to choose between Chrome and Microsoft Edge as the launched browser
-- Add `-browser-path` flag (env `KIOSK_BROWSER_PATH`) to point at an explicit Chromium-based browser executable; overrides `-browser`
+- Add `-browser` flag (env `KIOSK_BROWSER`, default `chrome`) to choose between Chrome and Microsoft Edge as the
+  launched browser
+- Add `-browser-path` flag (env `KIOSK_BROWSER_PATH`) to point at an explicit Chromium-based browser executable;
+  overrides `-browser`
 - Add `--incognito` flag to optionally disable Chrome incognito mode ([#127](https://github.com/grafana/grafana-kiosk/issues/127))
 - Add `-hide-logo` flag to hide Powered by Grafana logo ([#240](https://github.com/grafana/grafana-kiosk/issues/240))
 - Add `-hide-playlist-nav` flag to hide playlist navigation controls ([#240](https://github.com/grafana/grafana-kiosk/issues/240))

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ NOTE: Flags with parameters should use an "equals"
       oauth_auto_login is enabled in grafana config
   -autofit
       Fit panels to screen (default true)
+  -browser string
+      Browser to launch [chrome|edge] (default "chrome")
+  -browser-path string
+      Explicit path to a Chromium-based browser executable; overrides -browser
   -c string
       Path to configuration file (config.yaml)
   -field-password string

--- a/pkg/cmd/grafana-kiosk/main.go
+++ b/pkg/cmd/grafana-kiosk/main.go
@@ -56,6 +56,8 @@ type Args struct {
 	WindowPosition                       string
 	WindowSize                           string
 	ScaleFactor                          string
+	Browser                              string
+	BrowserPath                          string
 	HideLinks                            bool
 	HideLogo                             bool
 	HidePlaylistNav                      bool
@@ -79,6 +81,8 @@ func ProcessArgs(cfg interface{}) (Args, *flag.FlagSet) {
 	flagSettings.StringVar(&processedArgs.WindowPosition, "window-position", "0,0", "Top Left Position of Kiosk")
 	flagSettings.StringVar(&processedArgs.WindowSize, "window-size", "", "Size of Kiosk in pixels (width,height)")
 	flagSettings.StringVar(&processedArgs.ScaleFactor, "scale-factor", "1.0", "Scale factor, sort of zoom")
+	flagSettings.StringVar(&processedArgs.Browser, "browser", "chrome", "Browser to launch [chrome|edge]")
+	flagSettings.StringVar(&processedArgs.BrowserPath, "browser-path", "", "Explicit path to a Chromium-based browser executable; overrides -browser")
 	flagSettings.Int64Var(&processedArgs.PageLoadDelayMS, "page-load-delay-ms", 2000, "Delay in milliseconds before navigating to URL")
 	flagSettings.BoolVar(&processedArgs.IsPlayList, "playlists", false, "URL is a playlist")
 	flagSettings.BoolVar(&processedArgs.AutoFit, "autofit", true, "Fit panels to screen")
@@ -152,6 +156,8 @@ func loadConfig(args Args, fs *flag.FlagSet, cfg *kiosk.Config) error {
 		"window-position":    func() { cfg.General.WindowPosition = args.WindowPosition },
 		"window-size":        func() { cfg.General.WindowSize = args.WindowSize },
 		"scale-factor":       func() { cfg.General.ScaleFactor = args.ScaleFactor },
+		"browser":            func() { cfg.General.Browser = args.Browser },
+		"browser-path":       func() { cfg.General.BrowserPath = args.BrowserPath },
 		"page-load-delay-ms": func() { cfg.General.PageLoadDelayMS = args.PageLoadDelayMS },
 		"hide-links":         func() { cfg.General.HideLinks = args.HideLinks },
 		"hide-logo":          func() { cfg.General.HideLogo = args.HideLogo },
@@ -228,6 +234,8 @@ func logGeneralSettings(cfg *kiosk.Config) {
 	log.Println("WindowPosition:", cfg.General.WindowPosition)
 	log.Println("WindowSize:", cfg.General.WindowSize)
 	log.Println("ScaleFactor:", cfg.General.ScaleFactor)
+	log.Println("Browser:", cfg.General.Browser)
+	log.Println("BrowserPath:", cfg.General.BrowserPath)
 	log.Println("PageLoadDelayMS:", cfg.General.PageLoadDelayMS)
 	log.Println("HideLinks:", cfg.General.HideLinks)
 	log.Println("HideLogo:", cfg.General.HideLogo)
@@ -273,6 +281,14 @@ func main() {
 
 	if err := loadConfig(args, fs, &cfg); err != nil {
 		log.Println(err)
+		os.Exit(-1)
+	}
+
+	// validate browser selection
+	switch strings.ToLower(cfg.General.Browser) {
+	case "", "chrome", "edge":
+	default:
+		log.Println("Invalid browser", cfg.General.Browser, "- supported: chrome, edge")
 		os.Exit(-1)
 	}
 

--- a/pkg/cmd/grafana-kiosk/main_test.go
+++ b/pkg/cmd/grafana-kiosk/main_test.go
@@ -270,6 +270,8 @@ func TestProcessArgsAllFlags(t *testing.T) {
 			"-window-position", "100,200",
 			"-window-size", "1280,720",
 			"-scale-factor", "1.5",
+			"-browser", "edge",
+			"-browser-path", "/opt/edge/msedge",
 			"-page-load-delay-ms", "5000",
 			"-playlists",
 			"-autofit=false",
@@ -313,6 +315,8 @@ func TestProcessArgsAllFlags(t *testing.T) {
 			So(result.WindowPosition, ShouldEqual, "100,200")
 			So(result.WindowSize, ShouldEqual, "1280,720")
 			So(result.ScaleFactor, ShouldEqual, "1.5")
+			So(result.Browser, ShouldEqual, "edge")
+			So(result.BrowserPath, ShouldEqual, "/opt/edge/msedge")
 			So(result.PageLoadDelayMS, ShouldEqual, 5000)
 			So(result.HideLinks, ShouldBeTrue)
 			So(result.HideLogo, ShouldBeTrue)

--- a/pkg/kiosk/config.go
+++ b/pkg/kiosk/config.go
@@ -24,6 +24,8 @@ type General struct {
 	ScaleFactor     string `yaml:"scale-factor" env:"KIOSK_SCALE_FACTOR" env-default:"1.0" env-description:"Scale factor, like zoom"`
 	WindowPosition  string `yaml:"window-position" env:"KIOSK_WINDOW_POSITION" env-default:"0,0" env-description:"Top Left Position of Kiosk"`
 	WindowSize      string `yaml:"window-size" env:"KIOSK_WINDOW_SIZE" env-default:"" env-description:"Size of Kiosk in pixels (width,height)"`
+	Browser         string `yaml:"browser" env:"KIOSK_BROWSER" env-default:"chrome" env-description:"Browser to launch [chrome|edge]"`
+	BrowserPath     string `yaml:"browser-path" env:"KIOSK_BROWSER_PATH" env-default:"" env-description:"Explicit path to a Chromium-based browser executable; overrides -browser"`
 }
 
 // Target the dashboard/playlist details

--- a/pkg/kiosk/utils.go
+++ b/pkg/kiosk/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"os/exec"
 	"runtime"
 	"strconv"
 	"strings"
@@ -140,7 +141,50 @@ func generateExecutorOptions(dir string, cfg *Config) []chromedp.ExecAllocatorOp
 			chromedp.Flag("force-device-scale-factor", cfg.General.ScaleFactor))
 	}
 
+	if path := resolveBrowserExecPath(cfg); path != "" {
+		log.Printf("Using browser executable: %s", path)
+		execAllocatorOption = append(execAllocatorOption, chromedp.ExecPath(path))
+	}
+
 	return execAllocatorOption
+}
+
+// edgeBinaryCandidates lists executable names to look up on PATH when the
+// user requests the Edge browser. Order matters: first match wins.
+var edgeBinaryCandidates = []string{
+	"msedge",
+	"microsoft-edge",
+	"microsoft-edge-stable",
+}
+
+// lookPath is overridable in tests.
+var lookPath = exec.LookPath
+
+// resolveBrowserExecPath returns the explicit browser executable path that
+// should be passed to chromedp.ExecPath. An empty string means "let chromedp
+// auto-detect" (the default Chrome lookup).
+//
+// Precedence:
+//  1. cfg.General.BrowserPath (verbatim) if set
+//  2. cfg.General.Browser == "edge" → PATH lookup
+//  3. cfg.General.Browser == "chrome" or empty → "" (chromedp default)
+func resolveBrowserExecPath(cfg *Config) string {
+	if cfg.General.BrowserPath != "" {
+		return cfg.General.BrowserPath
+	}
+	switch strings.ToLower(cfg.General.Browser) {
+	case "", "chrome":
+		return ""
+	case "edge":
+		for _, name := range edgeBinaryCandidates {
+			if p, err := lookPath(name); err == nil {
+				return p
+			}
+		}
+		log.Println("Browser 'edge' requested but no Edge binary found on PATH; set -browser-path or KIOSK_BROWSER_PATH to the Edge executable")
+		return ""
+	}
+	return ""
 }
 
 // isFullscreenMode reports whether the given kiosk mode requires fullscreen.

--- a/pkg/kiosk/utils_test.go
+++ b/pkg/kiosk/utils_test.go
@@ -660,3 +660,64 @@ func TestWaitForBrowserStartup(t *testing.T) {
 		})
 	})
 }
+
+func TestResolveBrowserExecPath(t *testing.T) {
+	Convey("Given resolveBrowserExecPath", t, func() {
+		origLookPath := lookPath
+		defer func() { lookPath = origLookPath }()
+
+		Convey("When BrowserPath is set, it wins regardless of Browser", func() {
+			lookPath = func(string) (string, error) { return "/should/not/be/used", nil }
+			cfg := &Config{General: General{Browser: "edge", BrowserPath: "/custom/path/to/browser"}}
+			So(resolveBrowserExecPath(cfg), ShouldEqual, "/custom/path/to/browser")
+		})
+
+		Convey("When Browser is empty, returns empty (chromedp default)", func() {
+			cfg := &Config{General: General{Browser: ""}}
+			So(resolveBrowserExecPath(cfg), ShouldEqual, "")
+		})
+
+		Convey("When Browser is chrome, returns empty (chromedp default)", func() {
+			cfg := &Config{General: General{Browser: "chrome"}}
+			So(resolveBrowserExecPath(cfg), ShouldEqual, "")
+		})
+
+		Convey("When Browser is CHROME (case-insensitive), returns empty", func() {
+			cfg := &Config{General: General{Browser: "CHROME"}}
+			So(resolveBrowserExecPath(cfg), ShouldEqual, "")
+		})
+
+		Convey("When Browser is edge and msedge is on PATH, returns its path", func() {
+			lookPath = func(name string) (string, error) {
+				if name == "msedge" {
+					return "/usr/local/bin/msedge", nil
+				}
+				return "", fmt.Errorf("not found")
+			}
+			cfg := &Config{General: General{Browser: "edge"}}
+			So(resolveBrowserExecPath(cfg), ShouldEqual, "/usr/local/bin/msedge")
+		})
+
+		Convey("When Browser is edge and only microsoft-edge is on PATH, returns it", func() {
+			lookPath = func(name string) (string, error) {
+				if name == "microsoft-edge" {
+					return "/usr/bin/microsoft-edge", nil
+				}
+				return "", fmt.Errorf("not found")
+			}
+			cfg := &Config{General: General{Browser: "edge"}}
+			So(resolveBrowserExecPath(cfg), ShouldEqual, "/usr/bin/microsoft-edge")
+		})
+
+		Convey("When Browser is edge and nothing is on PATH, returns empty", func() {
+			lookPath = func(string) (string, error) { return "", fmt.Errorf("not found") }
+			cfg := &Config{General: General{Browser: "edge"}}
+			So(resolveBrowserExecPath(cfg), ShouldEqual, "")
+		})
+
+		Convey("When Browser is unknown, returns empty", func() {
+			cfg := &Config{General: General{Browser: "firefox"}}
+			So(resolveBrowserExecPath(cfg), ShouldEqual, "")
+		})
+	})
+}


### PR DESCRIPTION
Closes #266

## Summary

Adds the ability to launch the kiosk against either Chrome (default) or
Microsoft Edge, plus an explicit `-browser-path` / `KIOSK_BROWSER_PATH`
escape hatch for any Chromium-based binary.

Primary motivation: on Windows displays Edge ships preinstalled and Chrome
does not, so today the kiosk can't run out of the box. chromedp speaks the
Chrome DevTools Protocol and works against any Chromium-based browser, so
this is a small wiring change rather than a new dependency.

## Changes

| Flag            | Env                  | YAML            | Default  |
| --------------- | -------------------- | --------------- | -------- |
| `-browser`      | `KIOSK_BROWSER`      | `browser`       | `chrome` |
| `-browser-path` | `KIOSK_BROWSER_PATH` | `browser-path`  | `""`     |

Resolution logic (in `pkg/kiosk/utils.go::resolveBrowserExecPath`):

1. If `BrowserPath` is set → use it verbatim.
2. Else if `Browser == "edge"` → `exec.LookPath` for `msedge`,
   `microsoft-edge`, `microsoft-edge-stable` (first match wins).
3. Else (`chrome` or empty) → return `""` so chromedp's default detection
   runs (current behavior, no regression).
4. Unknown values rejected at startup with a clear error.

The resolved path is appended via `chromedp.ExecPath(...)` inside
`generateExecutorOptions`, so all eight login methods (`anon`, `local`,
`gcom`, `goauth`, `idtoken`, `apikey`, `aws`, `azuread`) inherit it
automatically.

## Out of scope

- **Firefox / Safari** — chromedp is CDP-only.
- **Hardcoded per-OS install paths** — `-browser-path` covers non-standard
  installs without bloating the binary with brittle path tables.
- **Auto-selecting Edge on Windows** — default stays `chrome` to preserve
  existing behavior; opting in is a single flag.

## Example

```bash
# Windows, use installed Edge
grafana-kiosk.exe -URL https://play.grafana.org -browser edge

# Any OS, custom Chromium build
grafana-kiosk -URL https://play.grafana.org \
  -browser-path "/opt/my-chromium/chrome"
```

YAML:

```yaml
general:
  browser: edge
  # or: browser-path: /opt/my-chromium/chrome
```

## Tests

New `TestResolveBrowserExecPath` (GoConvey) in
`pkg/kiosk/utils_test.go` covers: explicit-path override, empty / `chrome`
/ `CHROME` (case-insensitive) defaults, `edge` resolving via mocked
`lookPath` to `msedge` and `microsoft-edge`, missing-binary fallback, and
unknown browser. `TestProcessArgsAllFlags` extended with the new flags.
`resolveBrowserExecPath` reports 100% coverage.

## Verification

- `mage -v test:default` — all packages pass
- `golangci-lint run --timeout 5m ./pkg/...` — 0 issues
- `go vet ./...`, `gofmt -l pkg/` — clean

## Docs

- `README.md` — new `-browser` / `-browser-path` entries in the flags
  section.
- `CHANGELOG.md` — entries under Unreleased → Features and Tests.
