### PR TITLE
docs: add no-empty-Unreleased rule to release process

### DIFF
--- a/.agents/release.md
+++ b/.agents/release.md
@@ -33,8 +33,9 @@ pushed.
 2. **Merge any feature branches** that should be included in the release.
 
 3. **Verify the changelog** — `CHANGELOG.md` must have a section header
-   matching the new version number (without the `v` prefix). Cross-reference
-   all entries against the commits since the last tag:
+   matching the new version number (without the `v` prefix). Remove the
+   `[Unreleased]` header entirely — do not leave it as an empty section.
+   Cross-reference all entries against the commits since the last tag:
 
    ```sh
    git log <last-tag>..HEAD --oneline

--- a/.agents/release.md
+++ b/.agents/release.md
@@ -85,5 +85,28 @@ Pushing a `v*` tag triggers the CI workflow which:
 1. **Verify the release** — Go to the
    [GitHub Releases](https://github.com/grafana/grafana-kiosk/releases) page
    and confirm the artifacts are attached and downloadable.
-2. **Promote the release** — Edit the release on GitHub and uncheck
+
+2. **Rewrite the release notes** — CI auto-generates a flat commit list.
+   Replace it with categorized sections using `gh release edit`:
+
+   ```sh
+   gh release edit vX.X.X --repo grafana/grafana-kiosk --notes "..."
+   ```
+
+   Use this category order (omit empty categories):
+
+   | Category      | What goes here                               |
+   | ------------- | -------------------------------------------- |
+   | Features      | New flags, behaviours, login methods         |
+   | Bug Fixes     | Defect corrections                           |
+   | Tests         | New or updated test coverage                 |
+   | CI/CD         | Workflow, badge, permission changes          |
+   | Dependencies  | Go module and action version bumps           |
+   | Documentation | README, AGENTS.md, `.agents/` changes        |
+   | Chores        | Housekeeping with no user-facing effect      |
+
+   Each entry: `- Plain-English description ([#NNN](PR URL))`
+   First-time contributors get a **New Contributors** section at the bottom.
+
+3. **Promote the release** — Edit the release on GitHub and uncheck
    "Set as a pre-release" to make it a full release.

--- a/.agents/release.md
+++ b/.agents/release.md
@@ -97,7 +97,7 @@ Pushing a `v*` tag triggers the CI workflow which:
 
    | Category      | What goes here                               |
    | ------------- | -------------------------------------------- |
-   | Features      | New flags, behaviours, login methods         |
+   | Features      | New flags, behaviors, login methods         |
    | Bug Fixes     | Defect corrections                           |
    | Tests         | New or updated test coverage                 |
    | CI/CD         | Workflow, badge, permission changes          |

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage.html
 .idea
 .claude/
 docs/superpowers/
+.playwright-mcp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,8 +288,8 @@ Key deltas from vanilla Go:
 - **README**: update when CLI flags, env vars, defaults, login methods, or
   build targets change. Procedure:
   [`.agents/readme-policy.md`](.agents/readme-policy.md).
-- **Markdown**: run `npx markdownlint-cli2` on any `.md` file before
-  committing.
+- **Markdown**: run `npx markdownlint-cli2` then `npx cspell` on any `.md` file
+  before committing. Fix all issues before staging.
 - **Branching**: always create a feature branch (`feat/...`, `fix/...`).
   PR summaries use the same H3 categorization as the changelog and get
   updated after every push.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,7 +309,8 @@ abstractly ("be careful with Y"). If an existing line already covers the
 correction, tighten it instead of adding a new one. Remove lines when the
 underlying issue goes away (model upgrades, refactors, process changes).
 
-- (empty)
+- When releasing, remove the `[Unreleased]` header from `CHANGELOG.md` entirely — do not leave it as an empty section above
+  the new version.
 
 ---
 


### PR DESCRIPTION
## Documentation

- Remove `[Unreleased]` header entirely when cutting a release — do not leave it as an empty section above the new version entry
  - Rule added to `.agents/release.md` step 3 (pre-release checklist)
  - Rule added to `AGENTS.md` section 11 (Project Learnings)
- Add post-release step to rewrite auto-generated release notes into categorized sections
  - Category order: Features → Bug Fixes → Tests → CI/CD → Dependencies → Documentation → Chores
  - Includes `gh release edit` command and entry format
- Add `npx cspell` to markdown pre-commit policy in `AGENTS.md` section 10
  - Policy now requires markdownlint-cli2 then cspell, both clean before staging

## Chores

- Add `.playwright-mcp/` to `.gitignore`

## Test plan

- [ ] `.agents/release.md` step 3 mentions removing `[Unreleased]` header
- [ ] `.agents/release.md` post-release section has category table and `gh release edit` command
- [ ] `AGENTS.md` section 10 markdown policy includes cspell
- [ ] `AGENTS.md` section 11 has the concrete one-line release rule
- [ ] markdownlint and cspell pass on all changed files
<!-- octocov -->
## Code Metrics Report
| Coverage | Code to Test Ratio | Test Execution Time |
|---------:|-------------------:|--------------------:|
| 34.0%    | 1:0.9              | 3m17s               |



---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
