### PR TITLE
chore: move browser flag CHANGELOG entries to [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.12] - 2026-04-29
+## [Unreleased]
 
 ### Features
 
@@ -15,6 +15,15 @@ and this project adheres to
   launched browser
 - Add `-browser-path` flag (env `KIOSK_BROWSER_PATH`) to point at an explicit Chromium-based browser executable;
   overrides `-browser`
+
+### Tests
+
+- Add tests for `resolveBrowserExecPath` covering chrome default, custom path override, edge PATH lookup, and unknown browsers
+
+## [1.0.12] - 2026-04-29
+
+### Features
+
 - Add `--incognito` flag to optionally disable Chrome incognito mode ([#127](https://github.com/grafana/grafana-kiosk/issues/127))
 - Add `-hide-logo` flag to hide Powered by Grafana logo ([#240](https://github.com/grafana/grafana-kiosk/issues/240))
 - Add `-hide-playlist-nav` flag to hide playlist navigation controls ([#240](https://github.com/grafana/grafana-kiosk/issues/240))
@@ -35,7 +44,6 @@ and this project adheres to
 
 ### Tests
 
-- Add tests for `resolveBrowserExecPath` covering chrome default, custom path override, edge PATH lookup, and unknown browsers
 - Add tests for `IsDataSourceQueryRequest` and `IsTargetHostRequest` in apikey login
 - Add tests for `sanitize` in main and initialize packages
 - Add tests for `GenerateURL` playlist mode


### PR DESCRIPTION
## Summary

PR #267 (browser/edge flag support) merged after v1.0.12 was tagged, so its CHANGELOG entries landed inside `[1.0.12]` instead of `[Unreleased]`. This moves them to the correct section.

### Chores

- Move `-browser` and `-browser-path` feature entries from `[1.0.12]` to `[Unreleased]` in CHANGELOG.md
- Move `resolveBrowserExecPath` test entry from `[1.0.12]` Tests to `[Unreleased]` Tests

## Related

- Closes part of #272 (CHANGELOG fix; code fixes tracked separately)
<!-- octocov -->
## Code Metrics Report
| Coverage | Code to Test Ratio | Test Execution Time |
|---------:|-------------------:|--------------------:|
| 35.2%    | 1:0.9              | 3m14s               |



---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
