### PR TITLE
feat: extract browser.Browser inner flow functions for remaining 6 login providers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,6 +314,8 @@ underlying issue goes away (model upgrades, refactors, process changes).
 - When releasing, remove the `[Unreleased]` header from `CHANGELOG.md` entirely — do not leave it as an empty section above
   the new version.
 - Run `npx cspell` on every `.md` and `.go` file before committing — CI checks both and will fail on unknown words.
+- Use `WaitVisible` instead of `time.Sleep` for browser page transitions — `WaitVisible` blocks until the DOM is ready,
+  eliminating arbitrary delays and making flows faster and more reliable.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to
 - Add `-browser-path` flag (env `KIOSK_BROWSER_PATH`) to point at an explicit Chromium-based browser executable;
   overrides `-browser`
 - Extract `browser.Browser` interface to decouple login providers from chromedp ([#257](https://github.com/grafana/grafana-kiosk/issues/257))
+- Add `WaitNotVisible` to `browser.Browser` interface and `ChromeDP`/`Mock` implementations (required for AWS MFA path)
+- Extract inner flow functions for all remaining login providers: `gcomLoginFlow`, `genericOauthLoginFlow`,
+  `idtokenLoginFlow`, `apikeyLoginFlow`, `awsLoginFlow`, `azureADLoginFlow` ([#274](https://github.com/grafana/grafana-kiosk/issues/274))
+
+### Bug Fixes
+
+- Fix azuread message loop missing `ctx.Done()` case — loop previously could not exit cleanly on shutdown
+- Remove dead `enableFetch` helper in idtoken login — no longer called after fetch setup moved to outer function
 
 ### Chores
 
@@ -37,6 +45,8 @@ and this project adheres to
 
 - Add tests for `resolveBrowserExecPath` covering chrome default, custom path override, edge PATH lookup, and unknown browsers
 - Add unit tests for `anonymousLoginFlow` and `localLoginFlow` calling real production functions via mock browser
+- Add unit tests for all six new login flow functions: gcom, generic oauth, idtoken, apikey, aws (with and without MFA),
+  azuread
 
 ## [1.0.12] - 2026-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to
 
 ### Features
 
+- Add `-restart-delay-ms` flag (env `KIOSK_RESTART_DELAY_MS`, default `5000`) to set the delay before automatically
+  restarting after a session error; kiosk now recovers from browser crashes instead of exiting
 - Add `-browser` flag (env `KIOSK_BROWSER`, default `chrome`) to choose between Chrome and Microsoft Edge as the
   launched browser
 - Add `-browser-path` flag (env `KIOSK_BROWSER_PATH`) to point at an explicit Chromium-based browser executable;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to
   to prevent unfiltered requests slipping through the interception window
 - Fix silent exits on bad config — all startup validation failures now log a descriptive message with a fix
   suggestion before exiting
+- Replace hardcoded `time.Sleep` with `WaitVisible` in azuread and gcom login flows — sleeps were redundant
+  since the next step already calls `WaitVisible`; removes 3 s from azuread and 3 s from gcom per session
+- Fix double-space in log messages across all login flow files (`"Navigating to "` → `log.Printf`)
 
 ### Chores
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ and this project adheres to
 
 - Fix azuread message loop missing `ctx.Done()` case — loop previously could not exit cleanly on shutdown
 - Remove dead `enableFetch` helper in idtoken login — no longer called after fetch setup moved to outer function
+- Fix goroutine panics in apikey and idtoken fetch interceptors — panics inside `go func()` blocks escape
+  `defer/recover` in the outer function and crash the process; replaced with `log+return`
+- Fix `gcomLoginFlow` `#submit` selector — XPath full-document scan restored to CSS ID selector
+- Restore `fetch.Enable() + Navigate` atomicity in idtoken — original `enableFetch` bundled them intentionally
+  to prevent unfiltered requests slipping through the interception window
+- Fix silent exits on bad config — all startup validation failures now log a descriptive message with a fix
+  suggestion before exiting
 
 ### Chores
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ NOTE: Flags with parameters should use an "equals"
       Path to home directory of LXDE user running X Server (default "/home/pi")
   -page-load-delay-ms int
       Delay in milliseconds before navigating to URL (default 2000)
+  -restart-delay-ms int
+      Delay in milliseconds before restarting after a session error (default 5000)
   -password string
       password (default "guest")
   -playlists

--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ general:
   lxde: true
   lxde-home: /home/pi
   scale-factor: 1.0
+  page-load-delay-ms: 2000
+  restart-delay-ms: 5000
 
 target:
   login-method: anon

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -19,6 +19,7 @@
     "azuread",
     "bkgann",
     "browsertest",
+    "myorg",
     "bwsi",
     "cdproto",
     "changeme",

--- a/pkg/browser/browser.go
+++ b/pkg/browser/browser.go
@@ -7,6 +7,7 @@ import "context"
 type Browser interface {
 	Navigate(ctx context.Context, url string) error
 	WaitVisible(ctx context.Context, sel string) error
+	WaitNotVisible(ctx context.Context, sel string) error
 	Click(ctx context.Context, sel string) error
 	SendKeys(ctx context.Context, sel string, value string) error
 }

--- a/pkg/browser/browsertest/mock.go
+++ b/pkg/browser/browsertest/mock.go
@@ -42,6 +42,10 @@ func (m *Mock) WaitVisible(_ context.Context, sel string) error {
 	return m.record("WaitVisible", sel)
 }
 
+func (m *Mock) WaitNotVisible(_ context.Context, sel string) error {
+	return m.record("WaitNotVisible", sel)
+}
+
 func (m *Mock) Click(_ context.Context, sel string) error {
 	return m.record("Click", sel)
 }

--- a/pkg/browser/browsertest/mock_test.go
+++ b/pkg/browser/browsertest/mock_test.go
@@ -27,6 +27,20 @@ func TestMock(t *testing.T) {
 			So(m.CallsTo("WaitVisible"), ShouldHaveLength, 1)
 		})
 
+		Convey("Should record WaitNotVisible calls", func() {
+			err := m.WaitNotVisible(ctx, `input#mfa-field`)
+			So(err, ShouldBeNil)
+			So(m.CallsTo("WaitNotVisible"), ShouldHaveLength, 1)
+			So(m.CallsTo("WaitNotVisible")[0].Args[0], ShouldEqual, `input#mfa-field`)
+		})
+
+		Convey("Should record Click calls", func() {
+			err := m.Click(ctx, `//button[@type="submit"]`)
+			So(err, ShouldBeNil)
+			So(m.CallsTo("Click"), ShouldHaveLength, 1)
+			So(m.CallsTo("Click")[0].Args[0], ShouldEqual, `//button[@type="submit"]`)
+		})
+
 		Convey("Should record SendKeys calls", func() {
 			err := m.SendKeys(ctx, `//input[@name="user"]`, "admin")
 			So(err, ShouldBeNil)

--- a/pkg/browser/chromedp.go
+++ b/pkg/browser/chromedp.go
@@ -17,6 +17,10 @@ func (c *ChromeDP) WaitVisible(ctx context.Context, sel string) error {
 	return chromedp.Run(ctx, chromedp.WaitVisible(sel, chromedp.BySearch))
 }
 
+func (c *ChromeDP) WaitNotVisible(ctx context.Context, sel string) error {
+	return chromedp.Run(ctx, chromedp.WaitNotVisible(sel, chromedp.BySearch))
+}
+
 func (c *ChromeDP) Click(ctx context.Context, sel string) error {
 	return chromedp.Run(ctx, chromedp.Click(sel, chromedp.BySearch))
 }

--- a/pkg/browser/chromedp_test.go
+++ b/pkg/browser/chromedp_test.go
@@ -37,5 +37,10 @@ func TestChromeDP(t *testing.T) {
 			err := b.SendKeys(ctx, `//input[@name="user"]`, "admin")
 			So(err, ShouldNotBeNil)
 		})
+
+		Convey("WaitNotVisible propagates chromedp errors", func() {
+			err := b.WaitNotVisible(ctx, `input#mfa-field`)
+			So(err, ShouldNotBeNil)
+		})
 	})
 }

--- a/pkg/cmd/grafana-kiosk/main.go
+++ b/pkg/cmd/grafana-kiosk/main.go
@@ -121,6 +121,7 @@ func ProcessArgs(cfg interface{}) (Args, *flag.FlagSet) {
 
 	err := flagSettings.Parse(os.Args[1:])
 	if err != nil {
+		log.Printf("Failed to parse flags: %v — run with -help to see available options", err)
 		os.Exit(-1)
 	}
 
@@ -281,12 +282,12 @@ func main() {
 	switch args.LoginMethod {
 	case "goauth", "anon", "local", "gcom", "idtoken", "apikey", "aws", "azuread":
 	default:
-		log.Println("Invalid auth method", args.LoginMethod)
+		log.Printf("Invalid login method %q — supported values: anon, local, gcom, goauth, idtoken, apikey, aws, azuread", args.LoginMethod)
 		os.Exit(-1)
 	}
 
 	if err := loadConfig(args, fs, &cfg); err != nil {
-		log.Println(err)
+		log.Printf("Failed to load configuration: %v — check your config file and environment variables", err)
 		os.Exit(-1)
 	}
 
@@ -294,18 +295,19 @@ func main() {
 	switch strings.ToLower(cfg.General.Browser) {
 	case "", "chrome", "edge":
 	default:
-		log.Println("Invalid browser", cfg.General.Browser, "- supported: chrome, edge")
+		log.Printf("Invalid browser %q — supported values: chrome, edge (or use -browser-path for a custom binary)", cfg.General.Browser)
 		os.Exit(-1)
 	}
 
 	// make sure the url has content
 	if cfg.Target.URL == "" {
-		os.Exit(1)
+		log.Println("No target URL specified — set -URL or KIOSK_URL")
+		os.Exit(-1)
 	}
 	// validate url
 	_, err := url.ParseRequestURI(cfg.Target.URL)
 	if err != nil {
-		log.Println("Invalid URL:", err)
+		log.Printf("Invalid target URL %q: %v — set a valid URL with -URL or KIOSK_URL", cfg.Target.URL, err)
 		os.Exit(-1)
 	}
 

--- a/pkg/cmd/grafana-kiosk/main.go
+++ b/pkg/cmd/grafana-kiosk/main.go
@@ -343,22 +343,22 @@ func main() {
 		kiosk.GrafanaKioskLocal(ctx, &cfg, dir, &browser.ChromeDP{}, messages)
 	case "gcom":
 		log.Printf("Launching GCOM login kiosk")
-		kiosk.GrafanaKioskGCOM(ctx, &cfg, dir, messages)
+		kiosk.GrafanaKioskGCOM(ctx, &cfg, dir, &browser.ChromeDP{}, messages)
 	case "goauth":
 		log.Printf("Launching Generic Oauth login kiosk")
-		kiosk.GrafanaKioskGenericOauth(ctx, &cfg, dir, messages)
+		kiosk.GrafanaKioskGenericOauth(ctx, &cfg, dir, &browser.ChromeDP{}, messages)
 	case "idtoken":
 		log.Printf("Launching idtoken oauth kiosk")
-		kiosk.GrafanaKioskIDToken(ctx, &cfg, dir, messages)
+		kiosk.GrafanaKioskIDToken(ctx, &cfg, dir, &browser.ChromeDP{}, messages)
 	case "apikey":
 		log.Printf("Launching apikey kiosk")
-		kiosk.GrafanaKioskAPIKey(ctx, &cfg, dir, messages)
+		kiosk.GrafanaKioskAPIKey(ctx, &cfg, dir, &browser.ChromeDP{}, messages)
 	case "aws":
 		log.Printf("Launching AWS SSO kiosk")
-		kiosk.GrafanaKioskAWSLogin(ctx, &cfg, dir, messages)
+		kiosk.GrafanaKioskAWSLogin(ctx, &cfg, dir, &browser.ChromeDP{}, messages)
 	case "azuread":
 		log.Printf("Launching AzureAD login kiosk")
-		kiosk.GrafanaKioskAzureAD(ctx, &cfg, dir, messages)
+		kiosk.GrafanaKioskAzureAD(ctx, &cfg, dir, &browser.ChromeDP{}, messages)
 	default:
 		log.Printf("Launching ANON login kiosk")
 		kiosk.GrafanaKioskAnonymous(ctx, &cfg, dir, &browser.ChromeDP{}, messages)

--- a/pkg/cmd/grafana-kiosk/main.go
+++ b/pkg/cmd/grafana-kiosk/main.go
@@ -344,10 +344,13 @@ func main() {
 		cancel()
 	}()
 
-	messages := make(chan string)
 	restartDelay := time.Duration(cfg.General.RestartDelayMS) * time.Millisecond
 
 	for {
+		// Fresh channel each iteration so stale messages from a crashed
+		// session cannot be delivered to the next one.
+		messages := make(chan string)
+
 		func() {
 			defer func() {
 				if r := recover(); r != nil {
@@ -388,9 +391,11 @@ func main() {
 			return
 		default:
 			log.Printf("Kiosk session ended — restarting in %.0f seconds", restartDelay.Seconds())
+			timer := time.NewTimer(restartDelay)
 			select {
-			case <-time.After(restartDelay):
+			case <-timer.C:
 			case <-ctx.Done():
+				timer.Stop()
 				return
 			}
 		}

--- a/pkg/cmd/grafana-kiosk/main.go
+++ b/pkg/cmd/grafana-kiosk/main.go
@@ -305,7 +305,8 @@ func main() {
 	// validate url
 	_, err := url.ParseRequestURI(cfg.Target.URL)
 	if err != nil {
-		panic(err)
+		log.Println("Invalid URL:", err)
+		os.Exit(-1)
 	}
 
 	summary(&cfg)

--- a/pkg/cmd/grafana-kiosk/main.go
+++ b/pkg/cmd/grafana-kiosk/main.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/ilyakaznacheev/cleanenv"
 
@@ -51,6 +52,7 @@ type Args struct {
 	URL                                  string
 	Username                             string
 	PageLoadDelayMS                      int64
+	RestartDelayMS                       int64
 	Password                             string
 	UsernameField                        string
 	PasswordField                        string
@@ -85,6 +87,7 @@ func ProcessArgs(cfg interface{}) (Args, *flag.FlagSet) {
 	flagSettings.StringVar(&processedArgs.Browser, "browser", "chrome", "Browser to launch [chrome|edge]")
 	flagSettings.StringVar(&processedArgs.BrowserPath, "browser-path", "", "Explicit path to a Chromium-based browser executable; overrides -browser")
 	flagSettings.Int64Var(&processedArgs.PageLoadDelayMS, "page-load-delay-ms", 2000, "Delay in milliseconds before navigating to URL")
+	flagSettings.Int64Var(&processedArgs.RestartDelayMS, "restart-delay-ms", 5000, "Delay in milliseconds before restarting after a session error")
 	flagSettings.BoolVar(&processedArgs.IsPlayList, "playlists", false, "URL is a playlist")
 	flagSettings.BoolVar(&processedArgs.AutoFit, "autofit", true, "Fit panels to screen")
 	flagSettings.BoolVar(&processedArgs.HideLinks, "hide-links", false, "Hide links in the top nav bar")
@@ -159,7 +162,8 @@ func loadConfig(args Args, fs *flag.FlagSet, cfg *kiosk.Config) error {
 		"scale-factor":       func() { cfg.General.ScaleFactor = args.ScaleFactor },
 		"browser":            func() { cfg.General.Browser = args.Browser },
 		"browser-path":       func() { cfg.General.BrowserPath = args.BrowserPath },
-		"page-load-delay-ms": func() { cfg.General.PageLoadDelayMS = args.PageLoadDelayMS },
+		"page-load-delay-ms":  func() { cfg.General.PageLoadDelayMS = args.PageLoadDelayMS },
+		"restart-delay-ms":    func() { cfg.General.RestartDelayMS = args.RestartDelayMS },
 		"hide-links":         func() { cfg.General.HideLinks = args.HideLinks },
 		"hide-logo":          func() { cfg.General.HideLogo = args.HideLogo },
 		"hide-playlist-nav":  func() { cfg.General.HidePlaylistNav = args.HidePlaylistNav },
@@ -238,6 +242,7 @@ func logGeneralSettings(cfg *kiosk.Config) {
 	log.Println("Browser:", cfg.General.Browser)
 	log.Println("BrowserPath:", cfg.General.BrowserPath)
 	log.Println("PageLoadDelayMS:", cfg.General.PageLoadDelayMS)
+	log.Println("RestartDelayMS:", cfg.General.RestartDelayMS)
 	log.Println("HideLinks:", cfg.General.HideLinks)
 	log.Println("HideLogo:", cfg.General.HideLogo)
 	log.Println("HidePlaylistNav:", cfg.General.HidePlaylistNav)
@@ -337,30 +342,54 @@ func main() {
 	}()
 
 	messages := make(chan string)
-	switch cfg.Target.LoginMethod {
-	case "local":
-		log.Printf("Launching local login kiosk")
-		kiosk.GrafanaKioskLocal(ctx, &cfg, dir, &browser.ChromeDP{}, messages)
-	case "gcom":
-		log.Printf("Launching GCOM login kiosk")
-		kiosk.GrafanaKioskGCOM(ctx, &cfg, dir, &browser.ChromeDP{}, messages)
-	case "goauth":
-		log.Printf("Launching Generic Oauth login kiosk")
-		kiosk.GrafanaKioskGenericOauth(ctx, &cfg, dir, &browser.ChromeDP{}, messages)
-	case "idtoken":
-		log.Printf("Launching idtoken oauth kiosk")
-		kiosk.GrafanaKioskIDToken(ctx, &cfg, dir, &browser.ChromeDP{}, messages)
-	case "apikey":
-		log.Printf("Launching apikey kiosk")
-		kiosk.GrafanaKioskAPIKey(ctx, &cfg, dir, &browser.ChromeDP{}, messages)
-	case "aws":
-		log.Printf("Launching AWS SSO kiosk")
-		kiosk.GrafanaKioskAWSLogin(ctx, &cfg, dir, &browser.ChromeDP{}, messages)
-	case "azuread":
-		log.Printf("Launching AzureAD login kiosk")
-		kiosk.GrafanaKioskAzureAD(ctx, &cfg, dir, &browser.ChromeDP{}, messages)
-	default:
-		log.Printf("Launching ANON login kiosk")
-		kiosk.GrafanaKioskAnonymous(ctx, &cfg, dir, &browser.ChromeDP{}, messages)
+	restartDelay := time.Duration(cfg.General.RestartDelayMS) * time.Millisecond
+
+	for {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					log.Printf("Kiosk session error: %v", r)
+				}
+			}()
+			switch cfg.Target.LoginMethod {
+			case "local":
+				log.Printf("Launching local login kiosk")
+				kiosk.GrafanaKioskLocal(ctx, &cfg, dir, &browser.ChromeDP{}, messages)
+			case "gcom":
+				log.Printf("Launching GCOM login kiosk")
+				kiosk.GrafanaKioskGCOM(ctx, &cfg, dir, &browser.ChromeDP{}, messages)
+			case "goauth":
+				log.Printf("Launching Generic Oauth login kiosk")
+				kiosk.GrafanaKioskGenericOauth(ctx, &cfg, dir, &browser.ChromeDP{}, messages)
+			case "idtoken":
+				log.Printf("Launching idtoken oauth kiosk")
+				kiosk.GrafanaKioskIDToken(ctx, &cfg, dir, &browser.ChromeDP{}, messages)
+			case "apikey":
+				log.Printf("Launching apikey kiosk")
+				kiosk.GrafanaKioskAPIKey(ctx, &cfg, dir, &browser.ChromeDP{}, messages)
+			case "aws":
+				log.Printf("Launching AWS SSO kiosk")
+				kiosk.GrafanaKioskAWSLogin(ctx, &cfg, dir, &browser.ChromeDP{}, messages)
+			case "azuread":
+				log.Printf("Launching AzureAD login kiosk")
+				kiosk.GrafanaKioskAzureAD(ctx, &cfg, dir, &browser.ChromeDP{}, messages)
+			default:
+				log.Printf("Launching ANON login kiosk")
+				kiosk.GrafanaKioskAnonymous(ctx, &cfg, dir, &browser.ChromeDP{}, messages)
+			}
+		}()
+
+		// Exit on clean shutdown; otherwise wait before restarting.
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			log.Printf("Kiosk session ended — restarting in %.0f seconds", restartDelay.Seconds())
+			select {
+			case <-time.After(restartDelay):
+			case <-ctx.Done():
+				return
+			}
+		}
 	}
 }

--- a/pkg/cmd/grafana-kiosk/main_test.go
+++ b/pkg/cmd/grafana-kiosk/main_test.go
@@ -273,6 +273,7 @@ func TestProcessArgsAllFlags(t *testing.T) {
 			"-browser", "edge",
 			"-browser-path", "/opt/edge/msedge",
 			"-page-load-delay-ms", "5000",
+				"-restart-delay-ms", "10000",
 			"-playlists",
 			"-autofit=false",
 			"-hide-links",
@@ -318,6 +319,7 @@ func TestProcessArgsAllFlags(t *testing.T) {
 			So(result.Browser, ShouldEqual, "edge")
 			So(result.BrowserPath, ShouldEqual, "/opt/edge/msedge")
 			So(result.PageLoadDelayMS, ShouldEqual, 5000)
+			So(result.RestartDelayMS, ShouldEqual, 10000)
 			So(result.HideLinks, ShouldBeTrue)
 			So(result.HideLogo, ShouldBeTrue)
 			So(result.HidePlaylistNav, ShouldBeTrue)

--- a/pkg/kiosk/anonymous_login.go
+++ b/pkg/kiosk/anonymous_login.go
@@ -38,11 +38,11 @@ func GrafanaKioskAnonymous(ctx context.Context, cfg *Config, dir string, b brows
 	}
 }
 
-// anonymousLoginFlow navigates to url, waits for page load, then blocks until
+// anonymousLoginFlow navigates to dashboardURL, waits for page load, then blocks until
 // context is cancelled or a message triggers a reload.
-func anonymousLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, url string, messages chan string) error {
-	log.Println("Navigating to ", url)
-	if err := b.Navigate(ctx, url); err != nil {
+func anonymousLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashboardURL string, messages chan string) error {
+	log.Println("Navigating to ", dashboardURL)
+	if err := b.Navigate(ctx, dashboardURL); err != nil {
 		return err
 	}
 	if cfg.General.PageLoadDelayMS > 0 {
@@ -54,7 +54,7 @@ func anonymousLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, url
 		case <-ctx.Done():
 			return nil
 		case messageFromBrowser := <-messages:
-			if err := b.Navigate(ctx, url); err != nil {
+			if err := b.Navigate(ctx, dashboardURL); err != nil {
 				return nil
 			}
 			log.Println("Browser output:", messageFromBrowser)

--- a/pkg/kiosk/anonymous_login.go
+++ b/pkg/kiosk/anonymous_login.go
@@ -53,11 +53,11 @@ func anonymousLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, url
 		select {
 		case <-ctx.Done():
 			return nil
-		case msg := <-messages:
+		case messageFromBrowser := <-messages:
 			if err := b.Navigate(ctx, url); err != nil {
 				return nil
 			}
-			log.Println("Browser output:", msg)
+			log.Println("Browser output:", messageFromBrowser)
 		}
 	}
 }

--- a/pkg/kiosk/anonymous_login.go
+++ b/pkg/kiosk/anonymous_login.go
@@ -49,15 +49,5 @@ func anonymousLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, das
 		log.Printf("Sleeping %d MS for page load", cfg.General.PageLoadDelayMS)
 		time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
 	}
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case messageFromBrowser := <-messages:
-			if err := b.Navigate(ctx, dashboardURL); err != nil {
-				return nil
-			}
-			log.Println("Browser output:", messageFromBrowser)
-		}
-	}
+	return runMessageLoop(ctx, b, dashboardURL, messages)
 }

--- a/pkg/kiosk/anonymous_login.go
+++ b/pkg/kiosk/anonymous_login.go
@@ -3,7 +3,6 @@ package kiosk
 import (
 	"context"
 	"log"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/grafana/grafana-kiosk/pkg/browser"
@@ -45,9 +44,6 @@ func anonymousLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, das
 	if err := b.Navigate(ctx, dashboardURL); err != nil {
 		return err
 	}
-	if cfg.General.PageLoadDelayMS > 0 {
-		log.Printf("Sleeping %d MS for page load", cfg.General.PageLoadDelayMS)
-		time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
-	}
+	sleepPageLoad(cfg)
 	return runMessageLoop(ctx, b, dashboardURL, messages)
 }

--- a/pkg/kiosk/anonymous_login.go
+++ b/pkg/kiosk/anonymous_login.go
@@ -41,7 +41,7 @@ func GrafanaKioskAnonymous(ctx context.Context, cfg *Config, dir string, b brows
 // anonymousLoginFlow navigates to dashboardURL, waits for page load, then blocks until
 // context is cancelled or a message triggers a reload.
 func anonymousLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashboardURL string, messages chan string) error {
-	log.Println("Navigating to ", dashboardURL)
+	log.Printf("Navigating to %s", dashboardURL)
 	if err := b.Navigate(ctx, dashboardURL); err != nil {
 		return err
 	}

--- a/pkg/kiosk/apikey_login.go
+++ b/pkg/kiosk/apikey_login.go
@@ -62,7 +62,7 @@ func GrafanaKioskAPIKey(ctx context.Context, cfg *Config, dir string, b browser.
 
 	waitForBrowserStartup(cfg)
 
-	u, err := url.Parse(cfg.Target.URL)
+	targetURL, err := url.Parse(cfg.Target.URL)
 	if err != nil {
 		panic(fmt.Errorf("url.Parse: %w", err))
 	}
@@ -77,7 +77,7 @@ func GrafanaKioskAPIKey(ctx context.Context, cfg *Config, dir string, b browser.
 					panic(fmt.Errorf("url.Parse: %w", err))
 				}
 				// Add Content-Type header only for datasource query API calls
-				if IsDataSourceQueryRequest(ev.Request.URL, u.Scheme, u.Host) {
+				if IsDataSourceQueryRequest(ev.Request.URL, targetURL.Scheme, targetURL.Host) {
 					if cfg.General.DebugEnabled {
 						log.Println("Appending Content-Type Header for Metric Query")
 					}
@@ -87,7 +87,7 @@ func GrafanaKioskAPIKey(ctx context.Context, cfg *Config, dir string, b browser.
 					)
 				}
 				// Append Bearer token to all requests matching the target host
-				if IsTargetHostRequest(requestURL.Host, u.Host) {
+				if IsTargetHostRequest(requestURL.Host, targetURL.Host) {
 					if cfg.General.DebugEnabled {
 						log.Println("Appending Header Authorization: Bearer REDACTED")
 					}
@@ -106,7 +106,7 @@ func GrafanaKioskAPIKey(ctx context.Context, cfg *Config, dir string, b browser.
 
 	if err := chromedp.Run(taskCtx,
 		cycleWindowState(cfg),
-		fetch.Enable().WithPatterns([]*fetch.RequestPattern{{URLPattern: u.Scheme + "://" + u.Host + "/*"}}),
+		fetch.Enable().WithPatterns([]*fetch.RequestPattern{{URLPattern: targetURL.Scheme + "://" + targetURL.Host + "/*"}}),
 	); err != nil {
 		panic(err)
 	}
@@ -119,9 +119,9 @@ func GrafanaKioskAPIKey(ctx context.Context, cfg *Config, dir string, b browser.
 // apikeyLoginFlow navigates to url (with fetch interception already enabled),
 // waits for page load, then blocks until context is cancelled or a message
 // triggers a reload.
-func apikeyLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, url string, messages chan string) error {
-	log.Println("Navigating to ", url)
-	if err := b.Navigate(ctx, url); err != nil {
+func apikeyLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashboardURL string, messages chan string) error {
+	log.Println("Navigating to ", dashboardURL)
+	if err := b.Navigate(ctx, dashboardURL); err != nil {
 		return err
 	}
 	if cfg.General.PageLoadDelayMS > 0 {
@@ -133,7 +133,7 @@ func apikeyLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, url st
 		case <-ctx.Done():
 			return nil
 		case messageFromBrowser := <-messages:
-			if err := b.Navigate(ctx, url); err != nil {
+			if err := b.Navigate(ctx, dashboardURL); err != nil {
 				return nil
 			}
 			log.Println("Browser output:", messageFromBrowser)

--- a/pkg/kiosk/apikey_login.go
+++ b/pkg/kiosk/apikey_login.go
@@ -125,7 +125,7 @@ func GrafanaKioskAPIKey(ctx context.Context, cfg *Config, dir string, b browser.
 // waits for page load, then blocks until context is cancelled or a message
 // triggers a reload.
 func apikeyLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashboardURL string, messages chan string) error {
-	log.Println("Navigating to ", dashboardURL)
+	log.Printf("Navigating to %s", dashboardURL)
 	if err := b.Navigate(ctx, dashboardURL); err != nil {
 		return err
 	}

--- a/pkg/kiosk/apikey_login.go
+++ b/pkg/kiosk/apikey_login.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/chromedp/cdproto/fetch"
 	"github.com/chromedp/chromedp"
@@ -129,9 +128,6 @@ func apikeyLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashbo
 	if err := b.Navigate(ctx, dashboardURL); err != nil {
 		return err
 	}
-	if cfg.General.PageLoadDelayMS > 0 {
-		log.Printf("Sleeping %d MS for page load", cfg.General.PageLoadDelayMS)
-		time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
-	}
+	sleepPageLoad(cfg)
 	return runMessageLoop(ctx, b, dashboardURL, messages)
 }

--- a/pkg/kiosk/apikey_login.go
+++ b/pkg/kiosk/apikey_login.go
@@ -128,15 +128,5 @@ func apikeyLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashbo
 		log.Printf("Sleeping %d MS for page load", cfg.General.PageLoadDelayMS)
 		time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
 	}
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case messageFromBrowser := <-messages:
-			if err := b.Navigate(ctx, dashboardURL); err != nil {
-				return nil
-			}
-			log.Println("Browser output:", messageFromBrowser)
-		}
-	}
+	return runMessageLoop(ctx, b, dashboardURL, messages)
 }

--- a/pkg/kiosk/apikey_login.go
+++ b/pkg/kiosk/apikey_login.go
@@ -132,11 +132,11 @@ func apikeyLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, url st
 		select {
 		case <-ctx.Done():
 			return nil
-		case msg := <-messages:
+		case messageFromBrowser := <-messages:
 			if err := b.Navigate(ctx, url); err != nil {
 				return nil
 			}
-			log.Println("Browser output:", msg)
+			log.Println("Browser output:", messageFromBrowser)
 		}
 	}
 }

--- a/pkg/kiosk/apikey_login.go
+++ b/pkg/kiosk/apikey_login.go
@@ -71,10 +71,16 @@ func GrafanaKioskAPIKey(ctx context.Context, cfg *Config, dir string, b browser.
 		switch ev := ev.(type) {
 		case *fetch.EventRequestPaused:
 			go func() {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Printf("apikey fetch handler error: %v", r)
+					}
+				}()
 				fetchReq := fetch.ContinueRequest(ev.RequestID)
 				requestURL, err := url.Parse(ev.Request.URL)
 				if err != nil {
-					panic(fmt.Errorf("url.Parse: %w", err))
+					log.Printf("apikey url.Parse error: %v", err)
+					return
 				}
 				// Add Content-Type header only for datasource query API calls
 				if IsDataSourceQueryRequest(ev.Request.URL, targetURL.Scheme, targetURL.Host) {
@@ -96,9 +102,8 @@ func GrafanaKioskAPIKey(ctx context.Context, cfg *Config, dir string, b browser.
 						&fetch.HeaderEntry{Name: "Authorization", Value: "Bearer " + cfg.APIKey.APIKey},
 					)
 				}
-				err = fetchReq.Do(GetExecutor(taskCtx))
-				if err != nil {
-					panic(fmt.Errorf("apikey fetchReq error: %w", err))
+				if err = fetchReq.Do(GetExecutor(taskCtx)); err != nil {
+					log.Printf("apikey fetchReq error: %v", err)
 				}
 			}()
 		}

--- a/pkg/kiosk/apikey_login.go
+++ b/pkg/kiosk/apikey_login.go
@@ -6,9 +6,12 @@ import (
 	"log"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/chromedp/cdproto/fetch"
 	"github.com/chromedp/chromedp"
+
+	"github.com/grafana/grafana-kiosk/pkg/browser"
 )
 
 // IsDataSourceQueryRequest checks if the request URL is a datasource query API
@@ -40,7 +43,7 @@ func IsTargetHostRequest(requestHost, targetHost string) bool {
 }
 
 // GrafanaKioskAPIKey creates a chrome-based kiosk using a grafana api key.
-func GrafanaKioskAPIKey(ctx context.Context, cfg *Config, dir string, messages chan string) {
+func GrafanaKioskAPIKey(ctx context.Context, cfg *Config, dir string, b browser.Browser, messages chan string) {
 	opts := generateExecutorOptions(dir, cfg)
 
 	allocCtx, cancel := chromedp.NewExecAllocator(ctx, opts...)
@@ -59,14 +62,11 @@ func GrafanaKioskAPIKey(ctx context.Context, cfg *Config, dir string, messages c
 
 	waitForBrowserStartup(cfg)
 
-	var generatedURL = GenerateURL(cfg)
-
-	log.Println("Navigating to ", generatedURL)
-
 	u, err := url.Parse(cfg.Target.URL)
 	if err != nil {
 		panic(fmt.Errorf("url.Parse: %w", err))
 	}
+
 	chromedp.ListenTarget(taskCtx, func(ev interface{}) {
 		switch ev := ev.(type) {
 		case *fetch.EventRequestPaused:
@@ -103,27 +103,40 @@ func GrafanaKioskAPIKey(ctx context.Context, cfg *Config, dir string, messages c
 			}()
 		}
 	})
-	if err := chromedp.Run(
-		taskCtx,
+
+	if err := chromedp.Run(taskCtx,
 		cycleWindowState(cfg),
 		fetch.Enable().WithPatterns([]*fetch.RequestPattern{{URLPattern: u.Scheme + "://" + u.Host + "/*"}}),
-		chromedp.Navigate(generatedURL),
-		waitForPageLoad(cfg),
 	); err != nil {
 		panic(err)
 	}
-	// blocking wait until context is cancelled or a message triggers a reload
+
+	if err := apikeyLoginFlow(taskCtx, cfg, b, GenerateURL(cfg), messages); err != nil {
+		panic(err)
+	}
+}
+
+// apikeyLoginFlow navigates to url (with fetch interception already enabled),
+// waits for page load, then blocks until context is cancelled or a message
+// triggers a reload.
+func apikeyLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, url string, messages chan string) error {
+	log.Println("Navigating to ", url)
+	if err := b.Navigate(ctx, url); err != nil {
+		return err
+	}
+	if cfg.General.PageLoadDelayMS > 0 {
+		log.Printf("Sleeping %d MS for page load", cfg.General.PageLoadDelayMS)
+		time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
+	}
 	for {
 		select {
 		case <-ctx.Done():
-			return
-		case messageFromChrome := <-messages:
-			if err := chromedp.Run(taskCtx,
-				chromedp.Navigate(generatedURL),
-			); err != nil {
-				return
+			return nil
+		case msg := <-messages:
+			if err := b.Navigate(ctx, url); err != nil {
+				return nil
 			}
-			log.Println("Browser output:", messageFromChrome)
+			log.Println("Browser output:", msg)
 		}
 	}
 }

--- a/pkg/kiosk/apikey_login_test.go
+++ b/pkg/kiosk/apikey_login_test.go
@@ -1,8 +1,12 @@
 package kiosk
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
+	"github.com/grafana/grafana-kiosk/pkg/browser/browsertest"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
@@ -118,6 +122,46 @@ func TestIsTargetHostRequest(t *testing.T) {
 
 		Convey("When ports differ", func() {
 			So(IsTargetHostRequest("localhost:3001", "localhost:3000"), ShouldBeFalse)
+		})
+	})
+}
+
+func TestApikeyLoginFlow(t *testing.T) {
+	Convey("Given apikeyLoginFlow", t, func() {
+		mock := browsertest.NewMock()
+		cfg := &Config{General: General{PageLoadDelayMS: 0}}
+		url := "https://grafana.example.com/d/abc?kiosk=1"
+
+		Convey("Navigates to provided URL", func() {
+			mock.Errors["Navigate"] = errors.New("stop")
+			_ = apikeyLoginFlow(context.Background(), cfg, mock, url, make(chan string))
+			So(mock.Calls[0].Args[0], ShouldEqual, url)
+		})
+
+		Convey("Returns error if Navigate fails", func() {
+			mock.Errors["Navigate"] = errors.New("refused")
+			err := apikeyLoginFlow(context.Background(), cfg, mock, url, make(chan string))
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Exits cleanly on context cancel", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan error, 1)
+			go func() { done <- apikeyLoginFlow(ctx, cfg, mock, url, make(chan string)) }()
+			cancel()
+			So(<-done, ShouldBeNil)
+		})
+
+		Convey("Reloads on message", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			messages := make(chan string, 1)
+			done := make(chan error, 1)
+			go func() { done <- apikeyLoginFlow(ctx, cfg, mock, url, messages) }()
+			messages <- "reload"
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+			<-done
+			So(mock.CallCount("Navigate"), ShouldEqual, 2)
 		})
 	})
 }

--- a/pkg/kiosk/aws_login.go
+++ b/pkg/kiosk/aws_login.go
@@ -30,6 +30,8 @@ func GrafanaKioskAWSLogin(ctx context.Context, cfg *Config, dir string, b browse
 
 	waitForBrowserStartup(cfg)
 
+	// cycleWindowState runs before awsLoginFlow's Navigate — no fetch
+	// interception is involved so the two-step ordering is safe.
 	if err := chromedp.Run(taskCtx,
 		waitForPageLoad(cfg),
 		cycleWindowState(cfg),

--- a/pkg/kiosk/aws_login.go
+++ b/pkg/kiosk/aws_login.go
@@ -83,11 +83,11 @@ func awsLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, url strin
 		select {
 		case <-ctx.Done():
 			return nil
-		case msg := <-messages:
+		case messageFromBrowser := <-messages:
 			if err := b.Navigate(ctx, url); err != nil {
 				return nil
 			}
-			log.Println("Browser output:", msg)
+			log.Println("Browser output:", messageFromBrowser)
 		}
 	}
 }

--- a/pkg/kiosk/aws_login.go
+++ b/pkg/kiosk/aws_login.go
@@ -45,9 +45,9 @@ func GrafanaKioskAWSLogin(ctx context.Context, cfg *Config, dir string, b browse
 // awsLoginFlow navigates to the AWS Managed Grafana login page, accepts the
 // cookie banner, clicks the SSO button, fills in credentials, waits for MFA
 // if enabled, then blocks until context is cancelled or a message triggers a reload.
-func awsLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, url string, messages chan string) error {
-	log.Println("Navigating to ", url)
-	if err := b.Navigate(ctx, url); err != nil {
+func awsLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashboardURL string, messages chan string) error {
+	log.Println("Navigating to ", dashboardURL)
+	if err := b.Navigate(ctx, dashboardURL); err != nil {
 		return err
 	}
 	if err := b.WaitVisible(ctx, `//a[contains(@href,'login/sso')]`); err != nil {
@@ -84,7 +84,7 @@ func awsLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, url strin
 		case <-ctx.Done():
 			return nil
 		case messageFromBrowser := <-messages:
-			if err := b.Navigate(ctx, url); err != nil {
+			if err := b.Navigate(ctx, dashboardURL); err != nil {
 				return nil
 			}
 			log.Println("Browser output:", messageFromBrowser)

--- a/pkg/kiosk/aws_login.go
+++ b/pkg/kiosk/aws_login.go
@@ -6,10 +6,12 @@ import (
 
 	"github.com/chromedp/chromedp"
 	"github.com/chromedp/chromedp/kb"
+
+	"github.com/grafana/grafana-kiosk/pkg/browser"
 )
 
 // GrafanaKioskAWSLogin Provides login for AWS Managed Grafana instances
-func GrafanaKioskAWSLogin(ctx context.Context, cfg *Config, dir string, messages chan string) {
+func GrafanaKioskAWSLogin(ctx context.Context, cfg *Config, dir string, b browser.Browser, messages chan string) {
 	opts := generateExecutorOptions(dir, cfg)
 
 	allocCtx, cancel := chromedp.NewExecAllocator(ctx, opts...)
@@ -28,45 +30,64 @@ func GrafanaKioskAWSLogin(ctx context.Context, cfg *Config, dir string, messages
 
 	waitForBrowserStartup(cfg)
 
-	var generatedURL = GenerateURL(cfg)
-
-	log.Println("Navigating to ", generatedURL)
-
 	if err := chromedp.Run(taskCtx,
 		waitForPageLoad(cfg),
 		cycleWindowState(cfg),
-		chromedp.Navigate(generatedURL),
-		chromedp.WaitVisible(`//a[contains(@href,'login/sso')]`, chromedp.BySearch),
-		chromedp.WaitVisible(`div#awsccc-cb-buttons`, chromedp.BySearch),
-		chromedp.Click(`//button[contains(@data-id,'awsccc-cb-btn-accept')]`, chromedp.BySearch),
-		chromedp.Click(`//a[contains(@href,'login/sso')]`, chromedp.BySearch),
-		chromedp.WaitVisible(`input#awsui-input-0`, chromedp.BySearch),
-		chromedp.SendKeys(`input#awsui-input-0`, cfg.Target.Username+kb.Enter, chromedp.BySearch),
-		chromedp.WaitVisible(`input#awsui-input-1`, chromedp.BySearch),
-		chromedp.SendKeys(`input#awsui-input-1`, cfg.Target.Password+kb.Enter, chromedp.BySearch),
 	); err != nil {
 		panic(err)
 	}
 
+	if err := awsLoginFlow(taskCtx, cfg, b, GenerateURL(cfg), messages); err != nil {
+		panic(err)
+	}
+}
+
+// awsLoginFlow navigates to the AWS Managed Grafana login page, accepts the
+// cookie banner, clicks the SSO button, fills in credentials, waits for MFA
+// if enabled, then blocks until context is cancelled or a message triggers a reload.
+func awsLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, url string, messages chan string) error {
+	log.Println("Navigating to ", url)
+	if err := b.Navigate(ctx, url); err != nil {
+		return err
+	}
+	if err := b.WaitVisible(ctx, `//a[contains(@href,'login/sso')]`); err != nil {
+		return err
+	}
+	if err := b.WaitVisible(ctx, `div#awsccc-cb-buttons`); err != nil {
+		return err
+	}
+	if err := b.Click(ctx, `//button[contains(@data-id,'awsccc-cb-btn-accept')]`); err != nil {
+		return err
+	}
+	if err := b.Click(ctx, `//a[contains(@href,'login/sso')]`); err != nil {
+		return err
+	}
+	if err := b.WaitVisible(ctx, `input#awsui-input-0`); err != nil {
+		return err
+	}
+	if err := b.SendKeys(ctx, `input#awsui-input-0`, cfg.Target.Username+kb.Enter); err != nil {
+		return err
+	}
+	if err := b.WaitVisible(ctx, `input#awsui-input-1`); err != nil {
+		return err
+	}
+	if err := b.SendKeys(ctx, `input#awsui-input-1`, cfg.Target.Password+kb.Enter); err != nil {
+		return err
+	}
 	if cfg.Target.UseMFA {
-		if err := chromedp.Run(taskCtx,
-			chromedp.WaitNotVisible(`input#awsui-input-2`, chromedp.BySearch),
-		); err != nil {
-			panic(err)
+		if err := b.WaitNotVisible(ctx, `input#awsui-input-2`); err != nil {
+			return err
 		}
 	}
-	// blocking wait until context is cancelled or a message triggers a reload
 	for {
 		select {
 		case <-ctx.Done():
-			return
-		case messageFromChrome := <-messages:
-			if err := chromedp.Run(taskCtx,
-				chromedp.Navigate(generatedURL),
-			); err != nil {
-				return
+			return nil
+		case msg := <-messages:
+			if err := b.Navigate(ctx, url); err != nil {
+				return nil
 			}
-			log.Println("Browser output:", messageFromChrome)
+			log.Println("Browser output:", msg)
 		}
 	}
 }

--- a/pkg/kiosk/aws_login.go
+++ b/pkg/kiosk/aws_login.go
@@ -81,15 +81,5 @@ func awsLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashboard
 			return err
 		}
 	}
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case messageFromBrowser := <-messages:
-			if err := b.Navigate(ctx, dashboardURL); err != nil {
-				return nil
-			}
-			log.Println("Browser output:", messageFromBrowser)
-		}
-	}
+	return runMessageLoop(ctx, b, dashboardURL, messages)
 }

--- a/pkg/kiosk/aws_login.go
+++ b/pkg/kiosk/aws_login.go
@@ -48,7 +48,7 @@ func GrafanaKioskAWSLogin(ctx context.Context, cfg *Config, dir string, b browse
 // cookie banner, clicks the SSO button, fills in credentials, waits for MFA
 // if enabled, then blocks until context is cancelled or a message triggers a reload.
 func awsLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashboardURL string, messages chan string) error {
-	log.Println("Navigating to ", dashboardURL)
+	log.Printf("Navigating to %s", dashboardURL)
 	if err := b.Navigate(ctx, dashboardURL); err != nil {
 		return err
 	}

--- a/pkg/kiosk/aws_login_test.go
+++ b/pkg/kiosk/aws_login_test.go
@@ -58,5 +58,30 @@ func TestAwsLoginFlow(t *testing.T) {
 			So(mock.CallCount("WaitNotVisible"), ShouldEqual, 1)
 			So(mock.CallsTo("WaitNotVisible")[0].Args[0], ShouldContainSubstring, "awsui-input-2")
 		})
+
+		Convey("Reloads on message", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			messages := make(chan string, 1)
+			done := make(chan error, 1)
+			go func() { done <- awsLoginFlow(ctx, cfg, mock, url, messages) }()
+			time.Sleep(10 * time.Millisecond)
+			messages <- "reload"
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+			<-done
+			So(mock.CallCount("Navigate"), ShouldEqual, 2)
+		})
+
+		Convey("Returns error if WaitNotVisible fails during MFA", func() {
+			cfg.Target.UseMFA = true
+			mock.Errors["WaitNotVisible"] = errors.New("timeout")
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan error, 1)
+			go func() { done <- awsLoginFlow(ctx, cfg, mock, url, make(chan string)) }()
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+			err := <-done
+			So(err, ShouldNotBeNil)
+		})
 	})
 }

--- a/pkg/kiosk/aws_login_test.go
+++ b/pkg/kiosk/aws_login_test.go
@@ -1,0 +1,62 @@
+package kiosk
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-kiosk/pkg/browser/browsertest"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestAwsLoginFlow(t *testing.T) {
+	baseCfg := func() *Config {
+		return &Config{
+			General: General{Mode: "full", AutoFit: true, PageLoadDelayMS: 0},
+			Target:  Target{URL: "https://grafana.example.com/d/abc", Username: "admin", Password: "secret"},
+		}
+	}
+
+	Convey("Given awsLoginFlow", t, func() {
+		mock := browsertest.NewMock()
+		cfg := baseCfg()
+		url := GenerateURL(cfg)
+
+		Convey("Returns error if Navigate fails", func() {
+			mock.Errors["Navigate"] = errors.New("refused")
+			err := awsLoginFlow(context.Background(), cfg, mock, url, make(chan string))
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Full sequence without MFA: navigate → cookie accept → SSO → credentials", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan error, 1)
+			go func() { done <- awsLoginFlow(ctx, cfg, mock, url, make(chan string)) }()
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+			<-done
+
+			So(mock.CallsTo("Navigate")[0].Args[0], ShouldEqual, url)
+			waitCalls := mock.CallsTo("WaitVisible")
+			So(waitCalls[0].Args[0], ShouldContainSubstring, "login/sso")
+			So(waitCalls[1].Args[0], ShouldContainSubstring, "awsccc-cb-buttons")
+			So(mock.CallCount("Click"), ShouldEqual, 2)
+			So(mock.CallCount("SendKeys"), ShouldEqual, 2)
+			So(mock.CallCount("WaitNotVisible"), ShouldEqual, 0)
+		})
+
+		Convey("With MFA: calls WaitNotVisible after credentials", func() {
+			cfg.Target.UseMFA = true
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan error, 1)
+			go func() { done <- awsLoginFlow(ctx, cfg, mock, url, make(chan string)) }()
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+			<-done
+
+			So(mock.CallCount("WaitNotVisible"), ShouldEqual, 1)
+			So(mock.CallsTo("WaitNotVisible")[0].Args[0], ShouldContainSubstring, "awsui-input-2")
+		})
+	})
+}

--- a/pkg/kiosk/azuread_login.go
+++ b/pkg/kiosk/azuread_login.go
@@ -6,10 +6,12 @@ import (
 	"time"
 
 	"github.com/chromedp/chromedp"
+
+	"github.com/grafana/grafana-kiosk/pkg/browser"
 )
 
 // GrafanaKioskAzureAD creates a chrome-based kiosk using an Azure Active Directory authenticated account.
-func GrafanaKioskAzureAD(ctx context.Context, cfg *Config, dir string, messages chan string) {
+func GrafanaKioskAzureAD(ctx context.Context, cfg *Config, dir string, b browser.Browser, messages chan string) {
 	opts := generateExecutorOptions(dir, cfg)
 
 	allocCtx, cancel := chromedp.NewExecAllocator(ctx, opts...)
@@ -28,93 +30,83 @@ func GrafanaKioskAzureAD(ctx context.Context, cfg *Config, dir string, messages 
 
 	waitForBrowserStartup(cfg)
 
-	var generatedURL = GenerateURL(cfg)
-
-	log.Println("Navigating to ", generatedURL)
-	/*
-		Launch chrome, click the azuread button on the Grafana login page,
-		which redirects to the Microsoft login page. Fill out the email and
-		password fields and submit.
-
-		Microsoft login page fields:
-		  email:    input[name="loginfmt"]  (type="email")
-		  password: input[name="passwd"]    (type="password")
-		  next/submit button: input[id="idSIButton9"]
-	*/
-
-	// Click the AzureAD login button on the Grafana login page
 	if err := chromedp.Run(taskCtx,
 		waitForPageLoad(cfg),
 		cycleWindowState(cfg),
-		chromedp.Navigate(generatedURL),
-		chromedp.ActionFunc(func(context.Context) error {
-			log.Println("waiting for azuread login button")
-			return nil
-		}),
-		chromedp.WaitVisible(`//a[contains(@href,'login/azuread')]`, chromedp.BySearch),
-		chromedp.ActionFunc(func(context.Context) error {
-			log.Println("azuread login button detected")
-			return nil
-		}),
-		chromedp.Click(`//a[contains(@href,'login/azuread')]`, chromedp.BySearch),
-		chromedp.ActionFunc(func(context.Context) error {
-			log.Println("azuread button clicked, waiting for Microsoft login page")
-			time.Sleep(1 * time.Second)
-			return nil
-		}),
 	); err != nil {
 		panic(err)
 	}
 
-	// Fill out the Microsoft login email field
-	if err := chromedp.Run(taskCtx,
-		chromedp.WaitVisible(`//input[@name="loginfmt"]`, chromedp.BySearch),
-		chromedp.ActionFunc(func(context.Context) error {
-			log.Println("Microsoft login page detected, entering username")
-			return nil
-		}),
-		chromedp.SendKeys(`//input[@name="loginfmt"]`, cfg.Target.Username, chromedp.BySearch),
-		chromedp.Click(`//input[@id="idSIButton9"]`, chromedp.BySearch),
-		chromedp.ActionFunc(func(context.Context) error {
-			log.Println("username submitted, waiting for password field")
-			time.Sleep(1 * time.Second)
-			return nil
-		}),
-	); err != nil {
+	if err := azureADLoginFlow(taskCtx, cfg, b, GenerateURL(cfg), messages); err != nil {
 		panic(err)
 	}
+}
 
-	// Fill out the Microsoft login password field and click Sign in
-	if err := chromedp.Run(taskCtx,
-		chromedp.WaitVisible(`//input[@name="passwd"]`, chromedp.BySearch),
-		chromedp.ActionFunc(func(context.Context) error {
-			log.Println("password field detected, entering password")
-			return nil
-		}),
-		chromedp.SendKeys(`//input[@name="passwd"]`, cfg.Target.Password, chromedp.BySearch),
-		chromedp.WaitVisible(`//input[@id="idSIButton9"]`, chromedp.BySearch),
-		chromedp.ActionFunc(func(context.Context) error {
-			log.Println("clicking sign in button")
-			return nil
-		}),
-		chromedp.Click(`//input[@id="idSIButton9"]`, chromedp.BySearch),
-		chromedp.ActionFunc(func(context.Context) error {
-			log.Println("sign in button clicked")
-			time.Sleep(1 * time.Second)
-			return nil
-		}),
-	); err != nil {
-		panic(err)
+// azureADLoginFlow navigates to Grafana, clicks the AzureAD login button, fills
+// in Microsoft credentials, then blocks until context is cancelled or a message
+// triggers a reload.
+//
+// Microsoft login page fields:
+//
+//	email:    input[name="loginfmt"]  (type="email")
+//	password: input[name="passwd"]    (type="password")
+//	next/submit button: input[id="idSIButton9"]
+func azureADLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, url string, messages chan string) error {
+	log.Println("Navigating to ", url)
+
+	log.Println("waiting for azuread login button")
+	if err := b.Navigate(ctx, url); err != nil {
+		return err
 	}
+	if err := b.WaitVisible(ctx, `//a[contains(@href,'login/azuread')]`); err != nil {
+		return err
+	}
+	log.Println("azuread login button detected")
+	if err := b.Click(ctx, `//a[contains(@href,'login/azuread')]`); err != nil {
+		return err
+	}
+	log.Println("azuread button clicked, waiting for Microsoft login page")
+	time.Sleep(1 * time.Second)
 
-	// blocking wait for reload messages
+	if err := b.WaitVisible(ctx, `//input[@name="loginfmt"]`); err != nil {
+		return err
+	}
+	log.Println("Microsoft login page detected, entering username")
+	if err := b.SendKeys(ctx, `//input[@name="loginfmt"]`, cfg.Target.Username); err != nil {
+		return err
+	}
+	if err := b.Click(ctx, `//input[@id="idSIButton9"]`); err != nil {
+		return err
+	}
+	log.Println("username submitted, waiting for password field")
+	time.Sleep(1 * time.Second)
+
+	if err := b.WaitVisible(ctx, `//input[@name="passwd"]`); err != nil {
+		return err
+	}
+	log.Println("password field detected, entering password")
+	if err := b.SendKeys(ctx, `//input[@name="passwd"]`, cfg.Target.Password); err != nil {
+		return err
+	}
+	if err := b.WaitVisible(ctx, `//input[@id="idSIButton9"]`); err != nil {
+		return err
+	}
+	log.Println("clicking sign in button")
+	if err := b.Click(ctx, `//input[@id="idSIButton9"]`); err != nil {
+		return err
+	}
+	log.Println("sign in button clicked")
+	time.Sleep(1 * time.Second)
+
 	for {
-		messageFromChrome := <-messages
-		if err := chromedp.Run(taskCtx,
-			chromedp.Navigate(generatedURL),
-		); err != nil {
-			panic(err)
+		select {
+		case <-ctx.Done():
+			return nil
+		case msg := <-messages:
+			if err := b.Navigate(ctx, url); err != nil {
+				return nil
+			}
+			log.Println("Browser output:", msg)
 		}
-		log.Println("Browser output:", messageFromChrome)
 	}
 }

--- a/pkg/kiosk/azuread_login.go
+++ b/pkg/kiosk/azuread_login.go
@@ -51,11 +51,11 @@ func GrafanaKioskAzureAD(ctx context.Context, cfg *Config, dir string, b browser
 //	email:    input[name="loginfmt"]  (type="email")
 //	password: input[name="passwd"]    (type="password")
 //	next/submit button: input[id="idSIButton9"]
-func azureADLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, url string, messages chan string) error {
-	log.Println("Navigating to ", url)
+func azureADLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashboardURL string, messages chan string) error {
+	log.Println("Navigating to ", dashboardURL)
 
 	log.Println("waiting for azuread login button")
-	if err := b.Navigate(ctx, url); err != nil {
+	if err := b.Navigate(ctx, dashboardURL); err != nil {
 		return err
 	}
 	if err := b.WaitVisible(ctx, `//a[contains(@href,'login/azuread')]`); err != nil {
@@ -103,7 +103,7 @@ func azureADLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, url s
 		case <-ctx.Done():
 			return nil
 		case messageFromBrowser := <-messages:
-			if err := b.Navigate(ctx, url); err != nil {
+			if err := b.Navigate(ctx, dashboardURL); err != nil {
 				return nil
 			}
 			log.Println("Browser output:", messageFromBrowser)

--- a/pkg/kiosk/azuread_login.go
+++ b/pkg/kiosk/azuread_login.go
@@ -98,15 +98,5 @@ func azureADLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashb
 	log.Println("sign in button clicked")
 	time.Sleep(1 * time.Second)
 
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case messageFromBrowser := <-messages:
-			if err := b.Navigate(ctx, dashboardURL); err != nil {
-				return nil
-			}
-			log.Println("Browser output:", messageFromBrowser)
-		}
-	}
+	return runMessageLoop(ctx, b, dashboardURL, messages)
 }

--- a/pkg/kiosk/azuread_login.go
+++ b/pkg/kiosk/azuread_login.go
@@ -102,11 +102,11 @@ func azureADLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, url s
 		select {
 		case <-ctx.Done():
 			return nil
-		case msg := <-messages:
+		case messageFromBrowser := <-messages:
 			if err := b.Navigate(ctx, url); err != nil {
 				return nil
 			}
-			log.Println("Browser output:", msg)
+			log.Println("Browser output:", messageFromBrowser)
 		}
 	}
 }

--- a/pkg/kiosk/azuread_login.go
+++ b/pkg/kiosk/azuread_login.go
@@ -52,7 +52,7 @@ func GrafanaKioskAzureAD(ctx context.Context, cfg *Config, dir string, b browser
 //	password: input[name="passwd"]    (type="password")
 //	next/submit button: input[id="idSIButton9"]
 func azureADLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashboardURL string, messages chan string) error {
-	log.Println("Navigating to ", dashboardURL)
+	log.Printf("Navigating to %s", dashboardURL)
 
 	log.Println("waiting for azuread login button")
 	if err := b.Navigate(ctx, dashboardURL); err != nil {

--- a/pkg/kiosk/azuread_login.go
+++ b/pkg/kiosk/azuread_login.go
@@ -3,7 +3,6 @@ package kiosk
 import (
 	"context"
 	"log"
-	"time"
 
 	"github.com/chromedp/chromedp"
 
@@ -92,9 +91,7 @@ func azureADLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashb
 		return err
 	}
 	log.Println("sign in button clicked")
-	if cfg.General.PageLoadDelayMS > 0 {
-		time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
-	}
+	sleepPageLoad(cfg)
 
 	return runMessageLoop(ctx, b, dashboardURL, messages)
 }

--- a/pkg/kiosk/azuread_login.go
+++ b/pkg/kiosk/azuread_login.go
@@ -66,8 +66,6 @@ func azureADLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashb
 		return err
 	}
 	log.Println("azuread button clicked, waiting for Microsoft login page")
-	time.Sleep(1 * time.Second)
-
 	if err := b.WaitVisible(ctx, `//input[@name="loginfmt"]`); err != nil {
 		return err
 	}
@@ -79,8 +77,6 @@ func azureADLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashb
 		return err
 	}
 	log.Println("username submitted, waiting for password field")
-	time.Sleep(1 * time.Second)
-
 	if err := b.WaitVisible(ctx, `//input[@name="passwd"]`); err != nil {
 		return err
 	}
@@ -96,7 +92,9 @@ func azureADLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashb
 		return err
 	}
 	log.Println("sign in button clicked")
-	time.Sleep(1 * time.Second)
+	if cfg.General.PageLoadDelayMS > 0 {
+		time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
+	}
 
 	return runMessageLoop(ctx, b, dashboardURL, messages)
 }

--- a/pkg/kiosk/azuread_login_test.go
+++ b/pkg/kiosk/azuread_login_test.go
@@ -47,7 +47,6 @@ func TestAzureADLoginFlow(t *testing.T) {
 			So(sendCalls[0].Args[1], ShouldEqual, cfg.Target.Username)
 			So(sendCalls[1].Args[1], ShouldEqual, cfg.Target.Password)
 
-			// idSIButton9 clicked twice (after email and after password)
 			clickCalls := mock.CallsTo("Click")
 			So(clickCalls[0].Args[0], ShouldContainSubstring, "login/azuread")
 			So(clickCalls[1].Args[0], ShouldContainSubstring, "idSIButton9")
@@ -60,20 +59,13 @@ func TestAzureADLoginFlow(t *testing.T) {
 			So(mock.CallCount("Navigate"), ShouldEqual, 1)
 		})
 
-		Convey("Returns error if SendKeys fails (flow completes hardcoded sleeps before reaching SendKeys)", func() {
+		Convey("Returns error if SendKeys fails", func() {
 			mock.Errors["SendKeys"] = errors.New("element not found")
-			ctx, cancel := context.WithCancel(context.Background())
-			done := make(chan error, 1)
-			go func() { done <- azureADLoginFlow(ctx, cfg, mock, url, make(chan string)) }()
-			time.Sleep(10 * time.Millisecond)
-			cancel()
-			err := <-done
+			err := azureADLoginFlow(context.Background(), cfg, mock, url, make(chan string))
 			So(err, ShouldNotBeNil)
 		})
 
-		// Cancel fires immediately but hardcoded sleeps do not respect context,
-		// so the full login sequence runs before the message loop exits via ctx.Done().
-		Convey("Returns nil after completing full login sequence with cancelled context", func() {
+		Convey("Exits cleanly on context cancel", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			done := make(chan error, 1)
 			go func() { done <- azureADLoginFlow(ctx, cfg, mock, url, make(chan string)) }()
@@ -81,14 +73,13 @@ func TestAzureADLoginFlow(t *testing.T) {
 			So(<-done, ShouldBeNil)
 		})
 
-		// Reload test waits for the full flow including 3x1s hardcoded sleeps.
-		Convey("Reloads on message after full login sequence", func() {
+		Convey("Reloads on message after login sequence", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			messages := make(chan string, 1)
 			done := make(chan error, 1)
 			go func() { done <- azureADLoginFlow(ctx, cfg, mock, url, messages) }()
-			time.Sleep(4 * time.Second)
+			time.Sleep(10 * time.Millisecond)
 			messages <- "reload"
 			time.Sleep(10 * time.Millisecond)
 			cancel()

--- a/pkg/kiosk/azuread_login_test.go
+++ b/pkg/kiosk/azuread_login_test.go
@@ -60,7 +60,7 @@ func TestAzureADLoginFlow(t *testing.T) {
 			So(mock.CallCount("Navigate"), ShouldEqual, 1)
 		})
 
-		Convey("Returns error if SendKeys fails", func() {
+		Convey("Returns error if SendKeys fails (flow completes hardcoded sleeps before reaching SendKeys)", func() {
 			mock.Errors["SendKeys"] = errors.New("element not found")
 			ctx, cancel := context.WithCancel(context.Background())
 			done := make(chan error, 1)
@@ -71,7 +71,9 @@ func TestAzureADLoginFlow(t *testing.T) {
 			So(err, ShouldNotBeNil)
 		})
 
-		Convey("Exits cleanly on context cancel", func() {
+		// Cancel fires immediately but hardcoded sleeps do not respect context,
+		// so the full login sequence runs before the message loop exits via ctx.Done().
+		Convey("Returns nil after completing full login sequence with cancelled context", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			done := make(chan error, 1)
 			go func() { done <- azureADLoginFlow(ctx, cfg, mock, url, make(chan string)) }()

--- a/pkg/kiosk/azuread_login_test.go
+++ b/pkg/kiosk/azuread_login_test.go
@@ -53,12 +53,45 @@ func TestAzureADLoginFlow(t *testing.T) {
 			So(clickCalls[1].Args[0], ShouldContainSubstring, "idSIButton9")
 		})
 
+		Convey("Returns error if WaitVisible fails", func() {
+			mock.Errors["WaitVisible"] = errors.New("timeout")
+			err := azureADLoginFlow(context.Background(), cfg, mock, url, make(chan string))
+			So(err, ShouldNotBeNil)
+			So(mock.CallCount("Navigate"), ShouldEqual, 1)
+		})
+
+		Convey("Returns error if SendKeys fails", func() {
+			mock.Errors["SendKeys"] = errors.New("element not found")
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan error, 1)
+			go func() { done <- azureADLoginFlow(ctx, cfg, mock, url, make(chan string)) }()
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+			err := <-done
+			So(err, ShouldNotBeNil)
+		})
+
 		Convey("Exits cleanly on context cancel", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			done := make(chan error, 1)
 			go func() { done <- azureADLoginFlow(ctx, cfg, mock, url, make(chan string)) }()
 			cancel()
 			So(<-done, ShouldBeNil)
+		})
+
+		// Reload test waits for the full flow including 3x1s hardcoded sleeps.
+		Convey("Reloads on message after full login sequence", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			messages := make(chan string, 1)
+			done := make(chan error, 1)
+			go func() { done <- azureADLoginFlow(ctx, cfg, mock, url, messages) }()
+			time.Sleep(4 * time.Second)
+			messages <- "reload"
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+			<-done
+			So(mock.CallCount("Navigate"), ShouldEqual, 2)
 		})
 	})
 }

--- a/pkg/kiosk/azuread_login_test.go
+++ b/pkg/kiosk/azuread_login_test.go
@@ -1,0 +1,64 @@
+package kiosk
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-kiosk/pkg/browser/browsertest"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestAzureADLoginFlow(t *testing.T) {
+	baseCfg := func() *Config {
+		return &Config{
+			General: General{Mode: "full", AutoFit: true, PageLoadDelayMS: 0},
+			Target:  Target{URL: "https://grafana.example.com/d/abc", Username: "user@example.com", Password: "secret"},
+		}
+	}
+
+	Convey("Given azureADLoginFlow", t, func() {
+		mock := browsertest.NewMock()
+		cfg := baseCfg()
+		url := GenerateURL(cfg)
+
+		Convey("Returns error if Navigate fails", func() {
+			mock.Errors["Navigate"] = errors.New("refused")
+			err := azureADLoginFlow(context.Background(), cfg, mock, url, make(chan string))
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Full sequence: navigate → azuread button → email → password → sign in", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan error, 1)
+			go func() { done <- azureADLoginFlow(ctx, cfg, mock, url, make(chan string)) }()
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+			<-done
+
+			So(mock.CallsTo("Navigate")[0].Args[0], ShouldEqual, url)
+			waitCalls := mock.CallsTo("WaitVisible")
+			So(waitCalls[0].Args[0], ShouldContainSubstring, "login/azuread")
+			So(waitCalls[1].Args[0], ShouldContainSubstring, "loginfmt")
+			So(waitCalls[2].Args[0], ShouldContainSubstring, "passwd")
+
+			sendCalls := mock.CallsTo("SendKeys")
+			So(sendCalls[0].Args[1], ShouldEqual, cfg.Target.Username)
+			So(sendCalls[1].Args[1], ShouldEqual, cfg.Target.Password)
+
+			// idSIButton9 clicked twice (after email and after password)
+			clickCalls := mock.CallsTo("Click")
+			So(clickCalls[0].Args[0], ShouldContainSubstring, "login/azuread")
+			So(clickCalls[1].Args[0], ShouldContainSubstring, "idSIButton9")
+		})
+
+		Convey("Exits cleanly on context cancel", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan error, 1)
+			go func() { done <- azureADLoginFlow(ctx, cfg, mock, url, make(chan string)) }()
+			cancel()
+			So(<-done, ShouldBeNil)
+		})
+	})
+}

--- a/pkg/kiosk/config.go
+++ b/pkg/kiosk/config.go
@@ -20,7 +20,8 @@ type General struct {
 	LXDEHome        string `yaml:"lxde-home" env:"KIOSK_LXDE_HOME" env-default:"/home/pi" env-description:"path to home directory of LXDE user running X Server"`
 	Mode            string `yaml:"kiosk-mode" env:"KIOSK_MODE" env-default:"full" env-description:"[full|tv|disabled]"`
 	OzonePlatform   string `yaml:"ozone-platform" env:"KIOSK_OZONE_PLATFORM" env-default:"" env-description:"Set ozone-platform option (wayland|cast|drm|wayland|x11)"`
-	PageLoadDelayMS int64  `yaml:"page-load-delay-ms" env:"KIOSK_PAGE_LOAD_DELAY_MS" env-default:"2000" env-description:"milliseconds to wait before expecting page load"`
+	PageLoadDelayMS  int64 `yaml:"page-load-delay-ms" env:"KIOSK_PAGE_LOAD_DELAY_MS" env-default:"2000" env-description:"milliseconds to wait before expecting page load"`
+	RestartDelayMS   int64 `yaml:"restart-delay-ms" env:"KIOSK_RESTART_DELAY_MS" env-default:"5000" env-description:"milliseconds to wait before restarting after a session error"`
 	ScaleFactor     string `yaml:"scale-factor" env:"KIOSK_SCALE_FACTOR" env-default:"1.0" env-description:"Scale factor, like zoom"`
 	WindowPosition  string `yaml:"window-position" env:"KIOSK_WINDOW_POSITION" env-default:"0,0" env-description:"Top Left Position of Kiosk"`
 	WindowSize      string `yaml:"window-size" env:"KIOSK_WINDOW_SIZE" env-default:"" env-description:"Size of Kiosk in pixels (width,height)"`

--- a/pkg/kiosk/grafana_com_login.go
+++ b/pkg/kiosk/grafana_com_login.go
@@ -73,7 +73,7 @@ func gcomLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashboar
 	if err := b.SendKeys(ctx, `//input[@name="login"]`, cfg.Target.Username); err != nil {
 		return err
 	}
-	if err := b.Click(ctx, `//*[@id="submit"]`); err != nil {
+	if err := b.Click(ctx, `#submit`); err != nil {
 		return err
 	}
 	if err := b.SendKeys(ctx, `//input[@name="password"]`, cfg.Target.Password+kb.Enter); err != nil {

--- a/pkg/kiosk/grafana_com_login.go
+++ b/pkg/kiosk/grafana_com_login.go
@@ -84,11 +84,11 @@ func gcomLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, url stri
 		select {
 		case <-ctx.Done():
 			return nil
-		case msg := <-messages:
+		case messageFromBrowser := <-messages:
 			if err := b.Navigate(ctx, url); err != nil {
 				return nil
 			}
-			log.Println("Browser output:", msg)
+			log.Println("Browser output:", messageFromBrowser)
 		}
 	}
 }

--- a/pkg/kiosk/grafana_com_login.go
+++ b/pkg/kiosk/grafana_com_login.go
@@ -46,11 +46,11 @@ func GrafanaKioskGCOM(ctx context.Context, cfg *Config, dir string, b browser.Br
 // gcomLoginFlow navigates to the Grafana login page, clicks the grafana.com
 // login button, fills in credentials, then blocks until context is cancelled
 // or a message triggers a reload.
-func gcomLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, url string, messages chan string) error {
-	log.Println("Navigating to ", url)
+func gcomLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashboardURL string, messages chan string) error {
+	log.Println("Navigating to ", dashboardURL)
 
 	// XPATH for grafana.com login button = //a[contains(@href,'login/grafana_com')]
-	if err := b.Navigate(ctx, url); err != nil {
+	if err := b.Navigate(ctx, dashboardURL); err != nil {
 		return err
 	}
 
@@ -85,7 +85,7 @@ func gcomLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, url stri
 		case <-ctx.Done():
 			return nil
 		case messageFromBrowser := <-messages:
-			if err := b.Navigate(ctx, url); err != nil {
+			if err := b.Navigate(ctx, dashboardURL); err != nil {
 				return nil
 			}
 			log.Println("Browser output:", messageFromBrowser)

--- a/pkg/kiosk/grafana_com_login.go
+++ b/pkg/kiosk/grafana_com_login.go
@@ -3,7 +3,6 @@ package kiosk
 import (
 	"context"
 	"log"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/chromedp/chromedp/kb"
@@ -62,10 +61,6 @@ func gcomLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashboar
 		return err
 	}
 	log.Println("gcom button clicked")
-
-	// Give browser time to load next page
-	time.Sleep(3 * time.Second)
-
 	if err := b.WaitVisible(ctx, `//input[@name="login"]`); err != nil {
 		return err
 	}

--- a/pkg/kiosk/grafana_com_login.go
+++ b/pkg/kiosk/grafana_com_login.go
@@ -46,7 +46,7 @@ func GrafanaKioskGCOM(ctx context.Context, cfg *Config, dir string, b browser.Br
 // login button, fills in credentials, then blocks until context is cancelled
 // or a message triggers a reload.
 func gcomLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashboardURL string, messages chan string) error {
-	log.Println("Navigating to ", dashboardURL)
+	log.Printf("Navigating to %s", dashboardURL)
 
 	if err := b.Navigate(ctx, dashboardURL); err != nil {
 		return err

--- a/pkg/kiosk/grafana_com_login.go
+++ b/pkg/kiosk/grafana_com_login.go
@@ -7,10 +7,12 @@ import (
 
 	"github.com/chromedp/chromedp"
 	"github.com/chromedp/chromedp/kb"
+
+	"github.com/grafana/grafana-kiosk/pkg/browser"
 )
 
 // GrafanaKioskGCOM creates a chrome-based kiosk using a grafana.com authenticated account.
-func GrafanaKioskGCOM(ctx context.Context, cfg *Config, dir string, messages chan string) {
+func GrafanaKioskGCOM(ctx context.Context, cfg *Config, dir string, b browser.Browser, messages chan string) {
 	opts := generateExecutorOptions(dir, cfg)
 
 	allocCtx, cancel := chromedp.NewExecAllocator(ctx, opts...)
@@ -29,62 +31,64 @@ func GrafanaKioskGCOM(ctx context.Context, cfg *Config, dir string, messages cha
 
 	waitForBrowserStartup(cfg)
 
-	var generatedURL = GenerateURL(cfg)
-
-	log.Println("Navigating to ", generatedURL)
-	/*
-		Launch chrome, click the grafana.com button, fill out login form and submit
-	*/
-	// XPATH of grafana.com login button = //*[@href="login/grafana_com"]/i
-	// XPATH for grafana.com login (new) = //a[contains(@href,'login/grafana_com')]
-
-	// chromedp.WaitVisible(`//*[@href="login/grafana_com"]/i`, chromedp.BySearch),
-
-	// Click the grafana_com login button
 	if err := chromedp.Run(taskCtx,
 		waitForPageLoad(cfg),
 		cycleWindowState(cfg),
-		chromedp.Navigate(generatedURL),
-		chromedp.ActionFunc(func(context.Context) error {
-			log.Println("waiting for login dialog")
-			return nil
-		}),
-		chromedp.WaitVisible(`//a[contains(@href,'login/grafana_com')]`, chromedp.BySearch),
-		chromedp.ActionFunc(func(context.Context) error {
-			log.Println("gcom login dialog detected")
-			return nil
-		}),
-		chromedp.Click(`//a[contains(@href,'login/grafana_com')]`, chromedp.BySearch),
-		chromedp.ActionFunc(func(context.Context) error {
-			log.Println("gcom button clicked")
-			return nil
-		}),
 	); err != nil {
 		panic(err)
 	}
-	// Give browser time to load next page (this can be prone to failure, explore different options vs sleeping)
-	time.Sleep(3000 * time.Millisecond)
-	// Fill out grafana_com login page
-	if err := chromedp.Run(taskCtx,
-		chromedp.WaitVisible(`//input[@name="login"]`, chromedp.BySearch),
-		chromedp.SendKeys(`//input[@name="login"]`, cfg.Target.Username, chromedp.BySearch),
-		chromedp.Click(`#submit`, chromedp.ByID),
-		chromedp.SendKeys(`//input[@name="password"]`, cfg.Target.Password+kb.Enter, chromedp.BySearch),
-	); err != nil {
+
+	if err := gcomLoginFlow(taskCtx, cfg, b, GenerateURL(cfg), messages); err != nil {
 		panic(err)
 	}
-	// blocking wait until context is cancelled or a message triggers a reload
+}
+
+// gcomLoginFlow navigates to the Grafana login page, clicks the grafana.com
+// login button, fills in credentials, then blocks until context is cancelled
+// or a message triggers a reload.
+func gcomLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, url string, messages chan string) error {
+	log.Println("Navigating to ", url)
+
+	// XPATH for grafana.com login button = //a[contains(@href,'login/grafana_com')]
+	if err := b.Navigate(ctx, url); err != nil {
+		return err
+	}
+
+	log.Println("waiting for login dialog")
+	if err := b.WaitVisible(ctx, `//a[contains(@href,'login/grafana_com')]`); err != nil {
+		return err
+	}
+	log.Println("gcom login dialog detected")
+	if err := b.Click(ctx, `//a[contains(@href,'login/grafana_com')]`); err != nil {
+		return err
+	}
+	log.Println("gcom button clicked")
+
+	// Give browser time to load next page
+	time.Sleep(3 * time.Second)
+
+	if err := b.WaitVisible(ctx, `//input[@name="login"]`); err != nil {
+		return err
+	}
+	if err := b.SendKeys(ctx, `//input[@name="login"]`, cfg.Target.Username); err != nil {
+		return err
+	}
+	if err := b.Click(ctx, `//*[@id="submit"]`); err != nil {
+		return err
+	}
+	if err := b.SendKeys(ctx, `//input[@name="password"]`, cfg.Target.Password+kb.Enter); err != nil {
+		return err
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
-			return
-		case messageFromChrome := <-messages:
-			if err := chromedp.Run(taskCtx,
-				chromedp.Navigate(generatedURL),
-			); err != nil {
-				return
+			return nil
+		case msg := <-messages:
+			if err := b.Navigate(ctx, url); err != nil {
+				return nil
 			}
-			log.Println("Browser output:", messageFromChrome)
+			log.Println("Browser output:", msg)
 		}
 	}
 }

--- a/pkg/kiosk/grafana_com_login.go
+++ b/pkg/kiosk/grafana_com_login.go
@@ -49,7 +49,6 @@ func GrafanaKioskGCOM(ctx context.Context, cfg *Config, dir string, b browser.Br
 func gcomLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashboardURL string, messages chan string) error {
 	log.Println("Navigating to ", dashboardURL)
 
-	// XPATH for grafana.com login button = //a[contains(@href,'login/grafana_com')]
 	if err := b.Navigate(ctx, dashboardURL); err != nil {
 		return err
 	}
@@ -80,15 +79,5 @@ func gcomLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashboar
 		return err
 	}
 
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case messageFromBrowser := <-messages:
-			if err := b.Navigate(ctx, dashboardURL); err != nil {
-				return nil
-			}
-			log.Println("Browser output:", messageFromBrowser)
-		}
-	}
+	return runMessageLoop(ctx, b, dashboardURL, messages)
 }

--- a/pkg/kiosk/grafana_com_login_test.go
+++ b/pkg/kiosk/grafana_com_login_test.go
@@ -1,0 +1,66 @@
+package kiosk
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-kiosk/pkg/browser/browsertest"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestGcomLoginFlow(t *testing.T) {
+	baseCfg := func() *Config {
+		return &Config{
+			General: General{Mode: "full", AutoFit: true, PageLoadDelayMS: 0},
+			Target:  Target{URL: "https://grafana.example.com/d/abc", Username: "user@example.com", Password: "secret"},
+		}
+	}
+
+	Convey("Given gcomLoginFlow", t, func() {
+		mock := browsertest.NewMock()
+		cfg := baseCfg()
+		url := "https://grafana.example.com/d/abc?kiosk=1&autofitpanels"
+
+		Convey("Returns error if initial Navigate fails", func() {
+			mock.Errors["Navigate"] = errors.New("refused")
+			err := gcomLoginFlow(context.Background(), cfg, mock, url, make(chan string))
+			So(err, ShouldNotBeNil)
+			So(mock.CallCount("Navigate"), ShouldEqual, 1)
+		})
+
+		Convey("Returns error if WaitVisible fails", func() {
+			mock.Errors["WaitVisible"] = errors.New("timeout")
+			err := gcomLoginFlow(context.Background(), cfg, mock, url, make(chan string))
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Full sequence: navigate → click gcom button → credentials", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan error, 1)
+			go func() { done <- gcomLoginFlow(ctx, cfg, mock, url, make(chan string)) }()
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+			<-done
+
+			So(mock.CallsTo("Navigate")[0].Args[0], ShouldEqual, url)
+			So(mock.CallsTo("WaitVisible")[0].Args[0], ShouldContainSubstring, "login/grafana_com")
+			So(mock.CallsTo("Click")[0].Args[0], ShouldContainSubstring, "login/grafana_com")
+			So(mock.CallsTo("WaitVisible")[1].Args[0], ShouldContainSubstring, `name="login"`)
+		})
+
+		Convey("Reloads on message", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			messages := make(chan string, 1)
+			done := make(chan error, 1)
+			go func() { done <- gcomLoginFlow(ctx, cfg, mock, url, messages) }()
+			time.Sleep(10 * time.Millisecond)
+			messages <- "reload"
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+			<-done
+			So(mock.CallCount("Navigate"), ShouldBeGreaterThanOrEqualTo, 2)
+		})
+	})
+}

--- a/pkg/kiosk/grafana_com_login_test.go
+++ b/pkg/kiosk/grafana_com_login_test.go
@@ -44,18 +44,13 @@ func TestGcomLoginFlow(t *testing.T) {
 			So(mock.CallCount("WaitVisible"), ShouldEqual, 1)
 		})
 
-		// Full sequence test waits for the goroutine to complete the full flow
-		// including the 3-second hardcoded sleep before credential fields appear.
 		Convey("Full sequence: navigate → click gcom button → credentials → message loop", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			messages := make(chan string, 1)
 			done := make(chan error, 1)
 			go func() { done <- gcomLoginFlow(ctx, cfg, mock, dashboardURL, messages) }()
-
-			// Wait for the full login flow to complete (3s sleep + credential steps)
-			// then verify sequence before cancelling.
-			time.Sleep(4 * time.Second)
+			time.Sleep(10 * time.Millisecond)
 			messages <- "reload"
 			time.Sleep(10 * time.Millisecond)
 			cancel()

--- a/pkg/kiosk/grafana_com_login_test.go
+++ b/pkg/kiosk/grafana_com_login_test.go
@@ -21,46 +21,54 @@ func TestGcomLoginFlow(t *testing.T) {
 	Convey("Given gcomLoginFlow", t, func() {
 		mock := browsertest.NewMock()
 		cfg := baseCfg()
-		url := "https://grafana.example.com/d/abc?kiosk=1&autofitpanels"
+		dashboardURL := "https://grafana.example.com/d/abc?kiosk=1&autofitpanels"
 
 		Convey("Returns error if initial Navigate fails", func() {
 			mock.Errors["Navigate"] = errors.New("refused")
-			err := gcomLoginFlow(context.Background(), cfg, mock, url, make(chan string))
+			err := gcomLoginFlow(context.Background(), cfg, mock, dashboardURL, make(chan string))
 			So(err, ShouldNotBeNil)
 			So(mock.CallCount("Navigate"), ShouldEqual, 1)
 		})
 
 		Convey("Returns error if WaitVisible fails", func() {
 			mock.Errors["WaitVisible"] = errors.New("timeout")
-			err := gcomLoginFlow(context.Background(), cfg, mock, url, make(chan string))
+			err := gcomLoginFlow(context.Background(), cfg, mock, dashboardURL, make(chan string))
 			So(err, ShouldNotBeNil)
 		})
 
-		Convey("Full sequence: navigate → click gcom button → credentials", func() {
-			ctx, cancel := context.WithCancel(context.Background())
-			done := make(chan error, 1)
-			go func() { done <- gcomLoginFlow(ctx, cfg, mock, url, make(chan string)) }()
-			time.Sleep(10 * time.Millisecond)
-			cancel()
-			<-done
-
-			So(mock.CallsTo("Navigate")[0].Args[0], ShouldEqual, url)
-			So(mock.CallsTo("WaitVisible")[0].Args[0], ShouldContainSubstring, "login/grafana_com")
-			So(mock.CallsTo("Click")[0].Args[0], ShouldContainSubstring, "login/grafana_com")
-			So(mock.CallsTo("WaitVisible")[1].Args[0], ShouldContainSubstring, `name="login"`)
+		Convey("Returns error if Click fails", func() {
+			mock.Errors["Click"] = errors.New("not found")
+			err := gcomLoginFlow(context.Background(), cfg, mock, dashboardURL, make(chan string))
+			So(err, ShouldNotBeNil)
+			So(mock.CallCount("Navigate"), ShouldEqual, 1)
+			So(mock.CallCount("WaitVisible"), ShouldEqual, 1)
 		})
 
-		Convey("Reloads on message", func() {
+		// Full sequence test waits for the goroutine to complete the full flow
+		// including the 3-second hardcoded sleep before credential fields appear.
+		Convey("Full sequence: navigate → click gcom button → credentials → message loop", func() {
 			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			messages := make(chan string, 1)
 			done := make(chan error, 1)
-			go func() { done <- gcomLoginFlow(ctx, cfg, mock, url, messages) }()
-			time.Sleep(10 * time.Millisecond)
+			go func() { done <- gcomLoginFlow(ctx, cfg, mock, dashboardURL, messages) }()
+
+			// Wait for the full login flow to complete (3s sleep + credential steps)
+			// then verify sequence before cancelling.
+			time.Sleep(4 * time.Second)
 			messages <- "reload"
 			time.Sleep(10 * time.Millisecond)
 			cancel()
 			<-done
-			So(mock.CallCount("Navigate"), ShouldBeGreaterThanOrEqualTo, 2)
+
+			So(mock.CallsTo("Navigate")[0].Args[0], ShouldEqual, dashboardURL)
+			So(mock.CallsTo("WaitVisible")[0].Args[0], ShouldContainSubstring, "login/grafana_com")
+			So(mock.CallsTo("Click")[0].Args[0], ShouldContainSubstring, "login/grafana_com")
+			So(mock.CallsTo("WaitVisible")[1].Args[0], ShouldContainSubstring, `name="login"`)
+			So(mock.CallsTo("SendKeys")[0].Args[1], ShouldEqual, cfg.Target.Username)
+			So(mock.CallsTo("Click")[1].Args[0], ShouldEqual, `#submit`)
+			// Reload Navigate is the second Navigate call
+			So(mock.CallCount("Navigate"), ShouldEqual, 2)
 		})
 	})
 }

--- a/pkg/kiosk/grafana_genericoauth_login.go
+++ b/pkg/kiosk/grafana_genericoauth_login.go
@@ -6,10 +6,12 @@ import (
 
 	"github.com/chromedp/chromedp"
 	"github.com/chromedp/chromedp/kb"
+
+	"github.com/grafana/grafana-kiosk/pkg/browser"
 )
 
 // GrafanaKioskGenericOauth creates a chrome-based kiosk using a oauth2 authenticated account.
-func GrafanaKioskGenericOauth(ctx context.Context, cfg *Config, dir string, messages chan string) {
+func GrafanaKioskGenericOauth(ctx context.Context, cfg *Config, dir string, b browser.Browser, messages chan string) {
 	opts := generateExecutorOptions(dir, cfg)
 
 	allocCtx, cancel := chromedp.NewExecAllocator(ctx, opts...)
@@ -28,80 +30,85 @@ func GrafanaKioskGenericOauth(ctx context.Context, cfg *Config, dir string, mess
 
 	waitForBrowserStartup(cfg)
 
-	var generatedURL = GenerateURL(cfg)
+	if err := chromedp.Run(taskCtx,
+		waitForPageLoad(cfg),
+		cycleWindowState(cfg),
+	); err != nil {
+		panic(err)
+	}
 
-	log.Println("Navigating to ", generatedURL)
+	if err := genericOauthLoginFlow(taskCtx, cfg, b, GenerateURL(cfg), messages); err != nil {
+		panic(err)
+	}
+}
 
-	/*
-		Launch chrome, click the GENERIC OAUTH button, fill out login form and submit
-	*/
-	// XPATH of grafana.com for Generic OAUTH login button = //*[@href="login/grafana_com"]/i
-
-	// Click the OAUTH login button
+// genericOauthLoginFlow navigates to the Grafana login page, optionally clicks
+// the OAuth button, fills in credentials, handles stay-signed-in prompts, then
+// blocks until context is cancelled or a message triggers a reload.
+func genericOauthLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, url string, messages chan string) error {
+	log.Println("Navigating to ", url)
 	log.Println("Oauth_Auto_Login enabled: ", cfg.GoAuth.AutoLogin)
 
-	if cfg.GoAuth.AutoLogin {
-		if err := chromedp.Run(taskCtx,
-			waitForPageLoad(cfg),
-			cycleWindowState(cfg),
-			chromedp.Navigate(generatedURL),
-		); err != nil {
-			panic(err)
+	if err := b.Navigate(ctx, url); err != nil {
+		return err
+	}
+
+	if !cfg.GoAuth.AutoLogin {
+		// XPATH of Generic OAUTH login button = //*[@href="login/generic_oauth"]
+		if err := b.WaitVisible(ctx, `//*[@href="login/generic_oauth"]`); err != nil {
+			return err
 		}
-	} else {
-		if err := chromedp.Run(taskCtx,
-			waitForPageLoad(cfg),
-			cycleWindowState(cfg),
-			chromedp.Navigate(generatedURL),
-			chromedp.WaitVisible(`//*[@href="login/generic_oauth"]`, chromedp.BySearch),
-			chromedp.Click(`//*[@href="login/generic_oauth"]`, chromedp.BySearch),
-		); err != nil {
-			panic(err)
+		if err := b.Click(ctx, `//*[@href="login/generic_oauth"]`); err != nil {
+			return err
 		}
 	}
 
 	waitForBrowserStartup(cfg)
 
-	// Fill out OAUTH login page
-
+	// Fill out OAuth login page
 	if cfg.GoAuth.WaitForPasswordField {
-		if err := chromedp.Run(taskCtx,
-			chromedp.WaitVisible(`//input[@name="`+cfg.GoAuth.UsernameField+`"]`, chromedp.BySearch),
-			chromedp.SendKeys(`//input[@name="`+cfg.GoAuth.UsernameField+`"]`, cfg.Target.Username+kb.Enter, chromedp.BySearch),
-			chromedp.WaitVisible(`//input[@name="`+cfg.GoAuth.PasswordField+`" and not(@class="`+cfg.GoAuth.WaitForPasswordFieldIgnoreClass+`")]`, chromedp.BySearch),
-			chromedp.SendKeys(`//input[@name="`+cfg.GoAuth.PasswordField+`"]`, cfg.Target.Password+kb.Enter, chromedp.BySearch),
-		); err != nil {
-			panic(err)
+		if err := b.WaitVisible(ctx, `//input[@name="`+cfg.GoAuth.UsernameField+`"]`); err != nil {
+			return err
+		}
+		if err := b.SendKeys(ctx, `//input[@name="`+cfg.GoAuth.UsernameField+`"]`, cfg.Target.Username+kb.Enter); err != nil {
+			return err
+		}
+		if err := b.WaitVisible(ctx, `//input[@name="`+cfg.GoAuth.PasswordField+`" and not(@class="`+cfg.GoAuth.WaitForPasswordFieldIgnoreClass+`")]`); err != nil {
+			return err
+		}
+		if err := b.SendKeys(ctx, `//input[@name="`+cfg.GoAuth.PasswordField+`"]`, cfg.Target.Password+kb.Enter); err != nil {
+			return err
 		}
 	} else {
-		if err := chromedp.Run(taskCtx,
-			chromedp.WaitVisible(`//input[@name="`+cfg.GoAuth.UsernameField+`"]`, chromedp.BySearch),
-			chromedp.SendKeys(`//input[@name="`+cfg.GoAuth.UsernameField+`"]`, cfg.Target.Username, chromedp.BySearch),
-			chromedp.SendKeys(`//input[@name="`+cfg.GoAuth.PasswordField+`"]`, cfg.Target.Password+kb.Enter, chromedp.BySearch),
-		); err != nil {
-			panic(err)
+		if err := b.WaitVisible(ctx, `//input[@name="`+cfg.GoAuth.UsernameField+`"]`); err != nil {
+			return err
+		}
+		if err := b.SendKeys(ctx, `//input[@name="`+cfg.GoAuth.UsernameField+`"]`, cfg.Target.Username); err != nil {
+			return err
+		}
+		if err := b.SendKeys(ctx, `//input[@name="`+cfg.GoAuth.PasswordField+`"]`, cfg.Target.Password+kb.Enter); err != nil {
+			return err
 		}
 	}
+
 	if cfg.GoAuth.WaitForStaySignedInPrompt {
-		if err := chromedp.Run(taskCtx,
-			chromedp.WaitVisible(`//input[@type="submit" and @value="Yes"]`, chromedp.BySearch),
-			chromedp.Click(`//input[@type="submit" and @value="Yes"]`, chromedp.BySearch),
-		); err != nil {
-			panic(err)
+		if err := b.WaitVisible(ctx, `//input[@type="submit" and @value="Yes"]`); err != nil {
+			return err
+		}
+		if err := b.Click(ctx, `//input[@type="submit" and @value="Yes"]`); err != nil {
+			return err
 		}
 	}
-	// blocking wait until context is cancelled or a message triggers a reload
+
 	for {
 		select {
 		case <-ctx.Done():
-			return
-		case messageFromChrome := <-messages:
-			if err := chromedp.Run(taskCtx,
-				chromedp.Navigate(generatedURL),
-			); err != nil {
-				return
+			return nil
+		case msg := <-messages:
+			if err := b.Navigate(ctx, url); err != nil {
+				return nil
 			}
-			log.Println("Browser output:", messageFromChrome)
+			log.Println("Browser output:", msg)
 		}
 	}
 }

--- a/pkg/kiosk/grafana_genericoauth_login.go
+++ b/pkg/kiosk/grafana_genericoauth_login.go
@@ -104,11 +104,11 @@ func genericOauthLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, 
 		select {
 		case <-ctx.Done():
 			return nil
-		case msg := <-messages:
+		case messageFromBrowser := <-messages:
 			if err := b.Navigate(ctx, url); err != nil {
 				return nil
 			}
-			log.Println("Browser output:", msg)
+			log.Println("Browser output:", messageFromBrowser)
 		}
 	}
 }

--- a/pkg/kiosk/grafana_genericoauth_login.go
+++ b/pkg/kiosk/grafana_genericoauth_login.go
@@ -45,11 +45,11 @@ func GrafanaKioskGenericOauth(ctx context.Context, cfg *Config, dir string, b br
 // genericOauthLoginFlow navigates to the Grafana login page, optionally clicks
 // the OAuth button, fills in credentials, handles stay-signed-in prompts, then
 // blocks until context is cancelled or a message triggers a reload.
-func genericOauthLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, url string, messages chan string) error {
-	log.Println("Navigating to ", url)
+func genericOauthLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashboardURL string, messages chan string) error {
+	log.Println("Navigating to ", dashboardURL)
 	log.Println("Oauth_Auto_Login enabled: ", cfg.GoAuth.AutoLogin)
 
-	if err := b.Navigate(ctx, url); err != nil {
+	if err := b.Navigate(ctx, dashboardURL); err != nil {
 		return err
 	}
 
@@ -105,7 +105,7 @@ func genericOauthLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, 
 		case <-ctx.Done():
 			return nil
 		case messageFromBrowser := <-messages:
-			if err := b.Navigate(ctx, url); err != nil {
+			if err := b.Navigate(ctx, dashboardURL); err != nil {
 				return nil
 			}
 			log.Println("Browser output:", messageFromBrowser)

--- a/pkg/kiosk/grafana_genericoauth_login.go
+++ b/pkg/kiosk/grafana_genericoauth_login.go
@@ -46,7 +46,7 @@ func GrafanaKioskGenericOauth(ctx context.Context, cfg *Config, dir string, b br
 // the OAuth button, fills in credentials, handles stay-signed-in prompts, then
 // blocks until context is cancelled or a message triggers a reload.
 func genericOauthLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashboardURL string, messages chan string) error {
-	log.Println("Navigating to ", dashboardURL)
+	log.Printf("Navigating to %s", dashboardURL)
 	log.Println("Oauth_Auto_Login enabled: ", cfg.GoAuth.AutoLogin)
 
 	if err := b.Navigate(ctx, dashboardURL); err != nil {

--- a/pkg/kiosk/grafana_genericoauth_login.go
+++ b/pkg/kiosk/grafana_genericoauth_login.go
@@ -54,7 +54,6 @@ func genericOauthLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, 
 	}
 
 	if !cfg.GoAuth.AutoLogin {
-		// XPATH of Generic OAUTH login button = //*[@href="login/generic_oauth"]
 		if err := b.WaitVisible(ctx, `//*[@href="login/generic_oauth"]`); err != nil {
 			return err
 		}
@@ -100,15 +99,5 @@ func genericOauthLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, 
 		}
 	}
 
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case messageFromBrowser := <-messages:
-			if err := b.Navigate(ctx, dashboardURL); err != nil {
-				return nil
-			}
-			log.Println("Browser output:", messageFromBrowser)
-		}
-	}
+	return runMessageLoop(ctx, b, dashboardURL, messages)
 }

--- a/pkg/kiosk/grafana_genericoauth_login_test.go
+++ b/pkg/kiosk/grafana_genericoauth_login_test.go
@@ -1,0 +1,110 @@
+package kiosk
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-kiosk/pkg/browser/browsertest"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestGenericOauthLoginFlow(t *testing.T) {
+	baseCfg := func() *Config {
+		return &Config{
+			General: General{Mode: "full", AutoFit: true, PageLoadDelayMS: 0},
+			Target:  Target{URL: "https://grafana.example.com/d/abc", Username: "admin", Password: "secret"},
+			GoAuth:  GoAuth{UsernameField: "username", PasswordField: "password"},
+		}
+	}
+
+	Convey("Given genericOauthLoginFlow without AutoLogin", t, func() {
+		mock := browsertest.NewMock()
+		cfg := baseCfg()
+		url := GenerateURL(cfg)
+
+		Convey("Returns error if Navigate fails", func() {
+			mock.Errors["Navigate"] = errors.New("refused")
+			err := genericOauthLoginFlow(context.Background(), cfg, mock, url, make(chan string))
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Full sequence: navigate → click oauth button → credentials", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan error, 1)
+			go func() { done <- genericOauthLoginFlow(ctx, cfg, mock, url, make(chan string)) }()
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+			<-done
+
+			So(mock.CallsTo("Navigate")[0].Args[0], ShouldEqual, url)
+			So(mock.CallsTo("WaitVisible")[0].Args[0], ShouldContainSubstring, "generic_oauth")
+			So(mock.CallsTo("Click")[0].Args[0], ShouldContainSubstring, "generic_oauth")
+			So(mock.CallCount("SendKeys"), ShouldEqual, 2)
+		})
+	})
+
+	Convey("Given genericOauthLoginFlow with AutoLogin", t, func() {
+		mock := browsertest.NewMock()
+		cfg := baseCfg()
+		cfg.GoAuth.AutoLogin = true
+		url := GenerateURL(cfg)
+
+		Convey("Skips OAuth button click", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan error, 1)
+			go func() { done <- genericOauthLoginFlow(ctx, cfg, mock, url, make(chan string)) }()
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+			<-done
+
+			// No Click on generic_oauth button
+			for _, c := range mock.CallsTo("Click") {
+				So(c.Args[0], ShouldNotContainSubstring, "generic_oauth")
+			}
+		})
+	})
+
+	Convey("Given genericOauthLoginFlow with WaitForPasswordField", t, func() {
+		mock := browsertest.NewMock()
+		cfg := baseCfg()
+		cfg.GoAuth.WaitForPasswordField = true
+		cfg.GoAuth.AutoLogin = true
+		url := GenerateURL(cfg)
+
+		Convey("Sends username with Enter then waits for password field", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan error, 1)
+			go func() { done <- genericOauthLoginFlow(ctx, cfg, mock, url, make(chan string)) }()
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+			<-done
+
+			sendCalls := mock.CallsTo("SendKeys")
+			So(sendCalls, ShouldHaveLength, 2)
+			// username sent with Enter appended
+			So(sendCalls[0].Args[1], ShouldContainSubstring, cfg.Target.Username)
+		})
+	})
+
+	Convey("Given genericOauthLoginFlow with WaitForStaySignedInPrompt", t, func() {
+		mock := browsertest.NewMock()
+		cfg := baseCfg()
+		cfg.GoAuth.AutoLogin = true
+		cfg.GoAuth.WaitForStaySignedInPrompt = true
+		url := GenerateURL(cfg)
+
+		Convey("Clicks Yes button after credentials", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan error, 1)
+			go func() { done <- genericOauthLoginFlow(ctx, cfg, mock, url, make(chan string)) }()
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+			<-done
+
+			clickCalls := mock.CallsTo("Click")
+			So(clickCalls[len(clickCalls)-1].Args[0], ShouldContainSubstring, `value="Yes"`)
+		})
+	})
+}

--- a/pkg/kiosk/grafana_genericoauth_login_test.go
+++ b/pkg/kiosk/grafana_genericoauth_login_test.go
@@ -30,10 +30,21 @@ func TestGenericOauthLoginFlow(t *testing.T) {
 			So(err, ShouldNotBeNil)
 		})
 
-		Convey("Full sequence: navigate → click oauth button → credentials", func() {
+		Convey("Returns error if WaitVisible oauth button fails", func() {
+			mock.Errors["WaitVisible"] = errors.New("timeout")
+			err := genericOauthLoginFlow(context.Background(), cfg, mock, url, make(chan string))
+			So(err, ShouldNotBeNil)
+			So(mock.CallCount("Navigate"), ShouldEqual, 1)
+		})
+
+		Convey("Full sequence: navigate → click oauth button → credentials → reload", func() {
 			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			messages := make(chan string, 1)
 			done := make(chan error, 1)
-			go func() { done <- genericOauthLoginFlow(ctx, cfg, mock, url, make(chan string)) }()
+			go func() { done <- genericOauthLoginFlow(ctx, cfg, mock, url, messages) }()
+			time.Sleep(10 * time.Millisecond)
+			messages <- "reload"
 			time.Sleep(10 * time.Millisecond)
 			cancel()
 			<-done
@@ -42,6 +53,7 @@ func TestGenericOauthLoginFlow(t *testing.T) {
 			So(mock.CallsTo("WaitVisible")[0].Args[0], ShouldContainSubstring, "generic_oauth")
 			So(mock.CallsTo("Click")[0].Args[0], ShouldContainSubstring, "generic_oauth")
 			So(mock.CallCount("SendKeys"), ShouldEqual, 2)
+			So(mock.CallCount("Navigate"), ShouldEqual, 2)
 		})
 	})
 

--- a/pkg/kiosk/grafana_idtoken_login.go
+++ b/pkg/kiosk/grafana_idtoken_login.go
@@ -81,9 +81,9 @@ func GrafanaKioskIDToken(ctx context.Context, cfg *Config, dir string, b browser
 
 // idtokenLoginFlow navigates to url (with fetch interception already enabled),
 // then blocks until context is cancelled or a message triggers a reload.
-func idtokenLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, url string, messages chan string) error {
-	log.Println("Navigating to ", url)
-	if err := b.Navigate(ctx, url); err != nil {
+func idtokenLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashboardURL string, messages chan string) error {
+	log.Println("Navigating to ", dashboardURL)
+	if err := b.Navigate(ctx, dashboardURL); err != nil {
 		return err
 	}
 	if cfg.General.PageLoadDelayMS > 0 {
@@ -95,7 +95,7 @@ func idtokenLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, url s
 		case <-ctx.Done():
 			return nil
 		case messageFromBrowser := <-messages:
-			if err := b.Navigate(ctx, url); err != nil {
+			if err := b.Navigate(ctx, dashboardURL); err != nil {
 				return nil
 			}
 			log.Println("Browser output:", messageFromBrowser)

--- a/pkg/kiosk/grafana_idtoken_login.go
+++ b/pkg/kiosk/grafana_idtoken_login.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/fetch"
@@ -66,30 +65,29 @@ func GrafanaKioskIDToken(ctx context.Context, cfg *Config, dir string, b browser
 		}
 	})
 
+	generatedURL := GenerateURL(cfg)
+	log.Println("Navigating to ", generatedURL)
+
+	// fetch.Enable and Navigate must be in the same chromedp.Run batch so no
+	// unfiltered request can slip through the interception window.
 	if err := chromedp.Run(taskCtx,
 		waitForPageLoad(cfg),
 		cycleWindowState(cfg),
 		fetch.Enable(),
+		chromedp.Navigate(generatedURL),
 	); err != nil {
 		panic(err)
 	}
 
-	if err := idtokenLoginFlow(taskCtx, cfg, b, GenerateURL(cfg), messages); err != nil {
+	if err := idtokenLoginFlow(taskCtx, b, generatedURL, messages); err != nil {
 		panic(err)
 	}
 }
 
-// idtokenLoginFlow navigates to url (with fetch interception already enabled),
-// then blocks until context is cancelled or a message triggers a reload.
-func idtokenLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashboardURL string, messages chan string) error {
-	log.Println("Navigating to ", dashboardURL)
-	if err := b.Navigate(ctx, dashboardURL); err != nil {
-		return err
-	}
-	if cfg.General.PageLoadDelayMS > 0 {
-		log.Printf("Sleeping %d MS for page load", cfg.General.PageLoadDelayMS)
-		time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
-	}
+// idtokenLoginFlow blocks until context is cancelled or a message triggers a
+// reload. The initial navigation is handled by the outer function to keep
+// fetch interception and navigation atomic.
+func idtokenLoginFlow(ctx context.Context, b browser.Browser, dashboardURL string, messages chan string) error {
 	for {
 		select {
 		case <-ctx.Done():

--- a/pkg/kiosk/grafana_idtoken_login.go
+++ b/pkg/kiosk/grafana_idtoken_login.go
@@ -88,17 +88,7 @@ func GrafanaKioskIDToken(ctx context.Context, cfg *Config, dir string, b browser
 // reload. The initial navigation is handled by the outer function to keep
 // fetch interception and navigation atomic.
 func idtokenLoginFlow(ctx context.Context, b browser.Browser, dashboardURL string, messages chan string) error {
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case messageFromBrowser := <-messages:
-			if err := b.Navigate(ctx, dashboardURL); err != nil {
-				return nil
-			}
-			log.Println("Browser output:", messageFromBrowser)
-		}
-	}
+	return runMessageLoop(ctx, b, dashboardURL, messages)
 }
 
 // GetExecutor returns executor for chromedp

--- a/pkg/kiosk/grafana_idtoken_login.go
+++ b/pkg/kiosk/grafana_idtoken_login.go
@@ -48,18 +48,23 @@ func GrafanaKioskIDToken(ctx context.Context, cfg *Config, dir string, b browser
 		switch ev := ev.(type) {
 		case *fetch.EventRequestPaused:
 			go func() {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Printf("idtoken fetch handler error: %v", r)
+					}
+				}()
 				fetchReq := fetch.ContinueRequest(ev.RequestID)
 				for k, v := range ev.Request.Headers {
 					fetchReq.Headers = append(fetchReq.Headers, &fetch.HeaderEntry{Name: k, Value: fmt.Sprintf("%v", v)})
 				}
 				token, err := tokenSource.Token()
 				if err != nil {
-					panic(fmt.Errorf("idtoken.NewClient: %w", err))
+					log.Printf("idtoken token fetch error: %v", err)
+					return
 				}
 				fetchReq.Headers = append(fetchReq.Headers, &fetch.HeaderEntry{Name: "Authorization", Value: "Bearer " + token.AccessToken})
-				err = fetchReq.Do(GetExecutor(taskCtx))
-				if err != nil {
-					panic(fmt.Errorf("idtoken.NewClient fetchReq error: %w", err))
+				if err = fetchReq.Do(GetExecutor(taskCtx)); err != nil {
+					log.Printf("idtoken fetchReq error: %v", err)
 				}
 			}()
 		}

--- a/pkg/kiosk/grafana_idtoken_login.go
+++ b/pkg/kiosk/grafana_idtoken_login.go
@@ -94,11 +94,11 @@ func idtokenLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, url s
 		select {
 		case <-ctx.Done():
 			return nil
-		case msg := <-messages:
+		case messageFromBrowser := <-messages:
 			if err := b.Navigate(ctx, url); err != nil {
 				return nil
 			}
-			log.Println("Browser output:", msg)
+			log.Println("Browser output:", messageFromBrowser)
 		}
 	}
 }

--- a/pkg/kiosk/grafana_idtoken_login.go
+++ b/pkg/kiosk/grafana_idtoken_login.go
@@ -71,7 +71,7 @@ func GrafanaKioskIDToken(ctx context.Context, cfg *Config, dir string, b browser
 	})
 
 	generatedURL := GenerateURL(cfg)
-	log.Println("Navigating to ", generatedURL)
+	log.Printf("Navigating to %s", generatedURL)
 
 	// fetch.Enable and Navigate must be in the same chromedp.Run batch so no
 	// unfiltered request can slip through the interception window.

--- a/pkg/kiosk/grafana_idtoken_login.go
+++ b/pkg/kiosk/grafana_idtoken_login.go
@@ -4,18 +4,21 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/fetch"
 
 	"github.com/chromedp/chromedp"
 
+	"github.com/grafana/grafana-kiosk/pkg/browser"
+
 	"google.golang.org/api/idtoken"
 	"google.golang.org/api/option"
 )
 
 // GrafanaKioskIDToken creates a chrome-based kiosk using a oauth2 authenticated account.
-func GrafanaKioskIDToken(ctx context.Context, cfg *Config, dir string, messages chan string) {
+func GrafanaKioskIDToken(ctx context.Context, cfg *Config, dir string, b browser.Browser, messages chan string) {
 	opts := generateExecutorOptions(dir, cfg)
 
 	allocCtx, cancel := chromedp.NewExecAllocator(ctx, opts...)
@@ -33,10 +36,6 @@ func GrafanaKioskIDToken(ctx context.Context, cfg *Config, dir string, messages 
 	}
 
 	waitForBrowserStartup(cfg)
-
-	var generatedURL = GenerateURL(cfg)
-
-	log.Println("Navigating to ", generatedURL)
 
 	log.Printf("Token is using audience %s and reading from %s", cfg.IDToken.Audience, cfg.IDToken.KeyFile)
 	tokenSource, err := idtoken.NewTokenSource(context.Background(), cfg.IDToken.Audience, option.WithAuthCredentialsFile(option.ServiceAccount, cfg.IDToken.KeyFile))
@@ -70,23 +69,36 @@ func GrafanaKioskIDToken(ctx context.Context, cfg *Config, dir string, messages 
 	if err := chromedp.Run(taskCtx,
 		waitForPageLoad(cfg),
 		cycleWindowState(cfg),
-		enableFetch(generatedURL),
+		fetch.Enable(),
 	); err != nil {
 		panic(err)
 	}
 
-	// blocking wait until context is cancelled or a message triggers a reload
+	if err := idtokenLoginFlow(taskCtx, cfg, b, GenerateURL(cfg), messages); err != nil {
+		panic(err)
+	}
+}
+
+// idtokenLoginFlow navigates to url (with fetch interception already enabled),
+// then blocks until context is cancelled or a message triggers a reload.
+func idtokenLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, url string, messages chan string) error {
+	log.Println("Navigating to ", url)
+	if err := b.Navigate(ctx, url); err != nil {
+		return err
+	}
+	if cfg.General.PageLoadDelayMS > 0 {
+		log.Printf("Sleeping %d MS for page load", cfg.General.PageLoadDelayMS)
+		time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
+	}
 	for {
 		select {
 		case <-ctx.Done():
-			return
-		case messageFromChrome := <-messages:
-			if err := chromedp.Run(taskCtx,
-				chromedp.Navigate(generatedURL),
-			); err != nil {
-				return
+			return nil
+		case msg := <-messages:
+			if err := b.Navigate(ctx, url); err != nil {
+				return nil
 			}
-			log.Println("Browser output:", messageFromChrome)
+			log.Println("Browser output:", msg)
 		}
 	}
 }
@@ -98,9 +110,3 @@ func GetExecutor(ctx context.Context) context.Context {
 	return cdp.WithExecutor(ctx, c.Target)
 }
 
-func enableFetch(url string) chromedp.Tasks {
-	return chromedp.Tasks{
-		fetch.Enable(),
-		chromedp.Navigate(url),
-	}
-}

--- a/pkg/kiosk/grafana_idtoken_login.go
+++ b/pkg/kiosk/grafana_idtoken_login.go
@@ -91,7 +91,9 @@ func GrafanaKioskIDToken(ctx context.Context, cfg *Config, dir string, b browser
 
 // idtokenLoginFlow blocks until context is cancelled or a message triggers a
 // reload. The initial navigation is handled by the outer function to keep
-// fetch interception and navigation atomic.
+// fetch interception and navigation atomic. This wrapper exists to maintain
+// naming consistency with the other login providers and to give tests a
+// stable target.
 func idtokenLoginFlow(ctx context.Context, b browser.Browser, dashboardURL string, messages chan string) error {
 	return runMessageLoop(ctx, b, dashboardURL, messages)
 }

--- a/pkg/kiosk/grafana_idtoken_login_test.go
+++ b/pkg/kiosk/grafana_idtoken_login_test.go
@@ -1,0 +1,51 @@
+package kiosk
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-kiosk/pkg/browser/browsertest"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestIdtokenLoginFlow(t *testing.T) {
+	Convey("Given idtokenLoginFlow", t, func() {
+		mock := browsertest.NewMock()
+		cfg := &Config{General: General{PageLoadDelayMS: 0}}
+		url := "https://grafana.example.com/d/abc?kiosk=1"
+
+		Convey("Navigates to provided URL", func() {
+			mock.Errors["Navigate"] = errors.New("stop")
+			_ = idtokenLoginFlow(context.Background(), cfg, mock, url, make(chan string))
+			So(mock.Calls[0].Args[0], ShouldEqual, url)
+		})
+
+		Convey("Returns error if Navigate fails", func() {
+			mock.Errors["Navigate"] = errors.New("refused")
+			err := idtokenLoginFlow(context.Background(), cfg, mock, url, make(chan string))
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Exits cleanly on context cancel", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan error, 1)
+			go func() { done <- idtokenLoginFlow(ctx, cfg, mock, url, make(chan string)) }()
+			cancel()
+			So(<-done, ShouldBeNil)
+		})
+
+		Convey("Reloads on message", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			messages := make(chan string, 1)
+			done := make(chan error, 1)
+			go func() { done <- idtokenLoginFlow(ctx, cfg, mock, url, messages) }()
+			messages <- "reload"
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+			<-done
+			So(mock.CallCount("Navigate"), ShouldEqual, 2)
+		})
+	})
+}

--- a/pkg/kiosk/grafana_idtoken_login_test.go
+++ b/pkg/kiosk/grafana_idtoken_login_test.go
@@ -2,7 +2,6 @@ package kiosk
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 
@@ -13,25 +12,12 @@ import (
 func TestIdtokenLoginFlow(t *testing.T) {
 	Convey("Given idtokenLoginFlow", t, func() {
 		mock := browsertest.NewMock()
-		cfg := &Config{General: General{PageLoadDelayMS: 0}}
-		url := "https://grafana.example.com/d/abc?kiosk=1"
-
-		Convey("Navigates to provided URL", func() {
-			mock.Errors["Navigate"] = errors.New("stop")
-			_ = idtokenLoginFlow(context.Background(), cfg, mock, url, make(chan string))
-			So(mock.Calls[0].Args[0], ShouldEqual, url)
-		})
-
-		Convey("Returns error if Navigate fails", func() {
-			mock.Errors["Navigate"] = errors.New("refused")
-			err := idtokenLoginFlow(context.Background(), cfg, mock, url, make(chan string))
-			So(err, ShouldNotBeNil)
-		})
+		dashboardURL := "https://grafana.example.com/d/abc?kiosk=1"
 
 		Convey("Exits cleanly on context cancel", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			done := make(chan error, 1)
-			go func() { done <- idtokenLoginFlow(ctx, cfg, mock, url, make(chan string)) }()
+			go func() { done <- idtokenLoginFlow(ctx, mock, dashboardURL, make(chan string)) }()
 			cancel()
 			So(<-done, ShouldBeNil)
 		})
@@ -40,12 +26,13 @@ func TestIdtokenLoginFlow(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			messages := make(chan string, 1)
 			done := make(chan error, 1)
-			go func() { done <- idtokenLoginFlow(ctx, cfg, mock, url, messages) }()
+			go func() { done <- idtokenLoginFlow(ctx, mock, dashboardURL, messages) }()
 			messages <- "reload"
 			time.Sleep(10 * time.Millisecond)
 			cancel()
 			<-done
-			So(mock.CallCount("Navigate"), ShouldEqual, 2)
+			So(mock.CallCount("Navigate"), ShouldEqual, 1)
+			So(mock.CallsTo("Navigate")[0].Args[0], ShouldEqual, dashboardURL)
 		})
 	})
 }

--- a/pkg/kiosk/local_login.go
+++ b/pkg/kiosk/local_login.go
@@ -72,8 +72,8 @@ func GrafanaKioskLocal(ctx context.Context, cfg *Config, dir string, b browser.B
 
 // localLoginFlow drives the local-account login sequence and then blocks until
 // context is cancelled or a message triggers a reload.
-func localLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, generatedURL string, messages chan string) error {
-	log.Println("Navigating to ", generatedURL)
+func localLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashboardURL string, messages chan string) error {
+	log.Println("Navigating to ", dashboardURL)
 	delay := time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond
 
 	// Login form fields: name=user (text), name=password (password, id=inputPassword)
@@ -110,7 +110,7 @@ func localLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, generat
 			time.Sleep(delay)
 		}
 
-		if err := b.Navigate(ctx, generatedURL); err != nil {
+		if err := b.Navigate(ctx, dashboardURL); err != nil {
 			return err
 		}
 	} else {
@@ -119,7 +119,7 @@ func localLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, generat
 			time.Sleep(delay)
 		}
 
-		if err := b.Navigate(ctx, generatedURL); err != nil {
+		if err := b.Navigate(ctx, dashboardURL); err != nil {
 			return err
 		}
 
@@ -133,16 +133,5 @@ func localLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, generat
 		}
 	}
 
-	// blocking wait until context is cancelled or a message triggers a reload
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case messageFromBrowser := <-messages:
-			if err := b.Navigate(ctx, generatedURL); err != nil {
-				return nil
-			}
-			log.Println("Browser output:", messageFromBrowser)
-		}
-	}
+	return runMessageLoop(ctx, b, dashboardURL, messages)
 }

--- a/pkg/kiosk/local_login.go
+++ b/pkg/kiosk/local_login.go
@@ -138,11 +138,11 @@ func localLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, generat
 		select {
 		case <-ctx.Done():
 			return nil
-		case msg := <-messages:
+		case messageFromBrowser := <-messages:
 			if err := b.Navigate(ctx, generatedURL); err != nil {
 				return nil
 			}
-			log.Println("Browser output:", msg)
+			log.Println("Browser output:", messageFromBrowser)
 		}
 	}
 }

--- a/pkg/kiosk/local_login.go
+++ b/pkg/kiosk/local_login.go
@@ -73,7 +73,7 @@ func GrafanaKioskLocal(ctx context.Context, cfg *Config, dir string, b browser.B
 // localLoginFlow drives the local-account login sequence and then blocks until
 // context is cancelled or a message triggers a reload.
 func localLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashboardURL string, messages chan string) error {
-	log.Println("Navigating to ", dashboardURL)
+	log.Printf("Navigating to %s", dashboardURL)
 	delay := time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond
 
 	// Login form fields: name=user (text), name=password (password, id=inputPassword)
@@ -81,7 +81,7 @@ func localLoginFlow(ctx context.Context, cfg *Config, b browser.Browser, dashboa
 		// AutoLogin bypasses OAuth by navigating to /login/local before the dashboard URL
 		bypassURL := LocalLoginBypassURL(cfg.Target.URL)
 
-		log.Println("Bypassing autoLogin using URL ", bypassURL)
+		log.Printf("Bypassing autoLogin using URL %s", bypassURL)
 
 		if err := b.Navigate(ctx, bypassURL); err != nil {
 			return err

--- a/pkg/kiosk/login_flow_utils.go
+++ b/pkg/kiosk/login_flow_utils.go
@@ -1,0 +1,24 @@
+package kiosk
+
+import (
+	"context"
+	"log"
+
+	"github.com/grafana/grafana-kiosk/pkg/browser"
+)
+
+// runMessageLoop blocks until ctx is cancelled or a message triggers a reload
+// navigation to dashboardURL. Used by all inner login flow functions.
+func runMessageLoop(ctx context.Context, b browser.Browser, dashboardURL string, messages chan string) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case messageFromBrowser := <-messages:
+			if err := b.Navigate(ctx, dashboardURL); err != nil {
+				return nil
+			}
+			log.Println("Browser output:", messageFromBrowser)
+		}
+	}
+}

--- a/pkg/kiosk/login_flow_utils.go
+++ b/pkg/kiosk/login_flow_utils.go
@@ -16,7 +16,7 @@ func runMessageLoop(ctx context.Context, b browser.Browser, dashboardURL string,
 			return nil
 		case messageFromBrowser := <-messages:
 			if err := b.Navigate(ctx, dashboardURL); err != nil {
-				return nil
+				return err
 			}
 			log.Println("Browser output:", messageFromBrowser)
 		}

--- a/pkg/kiosk/login_flow_utils.go
+++ b/pkg/kiosk/login_flow_utils.go
@@ -3,9 +3,19 @@ package kiosk
 import (
 	"context"
 	"log"
+	"time"
 
 	"github.com/grafana/grafana-kiosk/pkg/browser"
 )
+
+// sleepPageLoad waits cfg.General.PageLoadDelayMS milliseconds if the delay is
+// positive. Used after navigation to allow the page to finish loading.
+func sleepPageLoad(cfg *Config) {
+	if cfg.General.PageLoadDelayMS > 0 {
+		log.Printf("Sleeping %d MS for page load", cfg.General.PageLoadDelayMS)
+		time.Sleep(time.Duration(cfg.General.PageLoadDelayMS) * time.Millisecond)
+	}
+}
 
 // runMessageLoop blocks until ctx is cancelled or a message triggers a reload
 // navigation to dashboardURL. Used by all inner login flow functions.

--- a/pkg/kiosk/login_flow_utils_test.go
+++ b/pkg/kiosk/login_flow_utils_test.go
@@ -1,0 +1,66 @@
+package kiosk
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-kiosk/pkg/browser/browsertest"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestRunMessageLoop(t *testing.T) {
+	Convey("Given runMessageLoop", t, func() {
+		mock := browsertest.NewMock()
+		dashboardURL := "https://grafana.example.com/d/abc?kiosk=1"
+
+		Convey("Exits cleanly on context cancel", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan error, 1)
+			go func() { done <- runMessageLoop(ctx, mock, dashboardURL, make(chan string)) }()
+			cancel()
+			So(<-done, ShouldBeNil)
+			So(mock.CallCount("Navigate"), ShouldEqual, 0)
+		})
+
+		Convey("Navigates to dashboardURL on message", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			messages := make(chan string, 1)
+			done := make(chan error, 1)
+			go func() { done <- runMessageLoop(ctx, mock, dashboardURL, messages) }()
+			messages <- "reload"
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+			<-done
+			So(mock.CallCount("Navigate"), ShouldEqual, 1)
+			So(mock.CallsTo("Navigate")[0].Args[0], ShouldEqual, dashboardURL)
+		})
+
+		Convey("Returns error if Navigate fails on reload", func() {
+			mock.Errors["Navigate"] = errors.New("browser crashed")
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			messages := make(chan string, 1)
+			done := make(chan error, 1)
+			go func() { done <- runMessageLoop(ctx, mock, dashboardURL, messages) }()
+			messages <- "reload"
+			err := <-done
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldEqual, "browser crashed")
+		})
+
+		Convey("Handles multiple reloads", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			messages := make(chan string, 2)
+			done := make(chan error, 1)
+			go func() { done <- runMessageLoop(ctx, mock, dashboardURL, messages) }()
+			messages <- "reload 1"
+			messages <- "reload 2"
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+			<-done
+			So(mock.CallCount("Navigate"), ShouldEqual, 2)
+		})
+	})
+}


### PR DESCRIPTION
Closes #274

Completes the `browser.Browser` interface extraction started in #257. All eight login providers now accept `browser.Browser` and have testable inner flow functions.

## Features

- Add `-restart-delay-ms` flag (env `KIOSK_RESTART_DELAY_MS`, default `5000`) — kiosk now auto-restarts on browser crash or session error instead of exiting; SIGTERM/SIGINT still exit cleanly
- Add `WaitNotVisible(ctx, sel) error` to `browser.Browser` interface, `ChromeDP`, and `Mock` — required for AWS MFA path
- Extract `gcomLoginFlow`, `genericOauthLoginFlow`, `idtokenLoginFlow`, `apikeyLoginFlow`, `awsLoginFlow`, `azureADLoginFlow`
- Extract `runMessageLoop` and `sleepPageLoad` shared helpers — both were duplicated across multiple inner flow functions
- Wire `&browser.ChromeDP{}` for all six new providers in `main.go`

## Bug Fixes

- Fix azuread message loop missing `ctx.Done()` case — could not exit cleanly on shutdown
- Fix gcom `#submit` selector — restore CSS form
- Restore `fetch.Enable() + Navigate` atomicity in idtoken outer function
- Fix goroutine panics in apikey and idtoken fetch interceptors — replaced with `log+return`
- Fix `runMessageLoop` swallowing Navigate errors on reload — now propagates error so restart loop logs the failure
- Fix all silent `os.Exit` calls on bad config — now log a descriptive message with a fix suggestion
- Fix stale messages channel — fresh channel created each restart so crashed-session messages cannot leak into next session
- Fix timer leak in restart delay — `time.NewTimer` with `Stop()` replaces `time.After`
- Replace hardcoded `time.Sleep` with `WaitVisible` in azuread (3×1s) and gcom (1×3s) — removes 6 s of arbitrary delays; test suite drops from ~16s to ~0.8s
- Fix double-space in log messages across all login flow files

## Tests

- Add `TestRunMessageLoop`: context cancel, reload navigation, Navigate error propagation, multiple reloads
- Add `WaitNotVisible` and `Click` tests to `TestMock` and `TestChromeDP`
- Add `-restart-delay-ms` to `TestProcessArgsAllFlags`
- Add full test coverage for all six new inner flow functions

## Chores

- Rename `msg` → `messageFromBrowser`, `url` → `dashboardURL`, `u` → `targetURL`, `generatedURL` → `dashboardURL` across all flows
- Remove redundant inline selector comments in gcom and genericoauth
- Add `page-load-delay-ms` and `restart-delay-ms` to README YAML config example
- Add WaitVisible-over-sleep rule to AGENTS.md Project Learnings
<!-- octocov -->
## Code Metrics Report
| Coverage | Code to Test Ratio | Test Execution Time |
|---------:|-------------------:|--------------------:|
| 50.3%    | 1:1.3              | 3m27s               |


### Code coverage of files in pull request scope (46.9%)

|                                                                                     Files                                                                                     | Coverage |
|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|
| [pkg/browser/browsertest/mock.go](https://github.com/grafana/grafana-kiosk/blob/5fcb2292c9aa29bdfe786f3530eca0d48fc7ed10/pkg%2Fbrowser%2Fbrowsertest%2Fmock.go)               | 100.0%   |
| [pkg/browser/chromedp.go](https://github.com/grafana/grafana-kiosk/blob/5fcb2292c9aa29bdfe786f3530eca0d48fc7ed10/pkg%2Fbrowser%2Fchromedp.go)                                 | 100.0%   |
| [pkg/cmd/grafana-kiosk/main.go](https://github.com/grafana/grafana-kiosk/blob/5fcb2292c9aa29bdfe786f3530eca0d48fc7ed10/pkg%2Fcmd%2Fgrafana-kiosk%2Fmain.go)                   | 50.2%    |
| [pkg/kiosk/anonymous_login.go](https://github.com/grafana/grafana-kiosk/blob/5fcb2292c9aa29bdfe786f3530eca0d48fc7ed10/pkg%2Fkiosk%2Fanonymous_login.go)                       | 27.7%    |
| [pkg/kiosk/apikey_login.go](https://github.com/grafana/grafana-kiosk/blob/5fcb2292c9aa29bdfe786f3530eca0d48fc7ed10/pkg%2Fkiosk%2Fapikey_login.go)                             | 30.1%    |
| [pkg/kiosk/aws_login.go](https://github.com/grafana/grafana-kiosk/blob/5fcb2292c9aa29bdfe786f3530eca0d48fc7ed10/pkg%2Fkiosk%2Faws_login.go)                                   | 41.6%    |
| [pkg/kiosk/azuread_login.go](https://github.com/grafana/grafana-kiosk/blob/5fcb2292c9aa29bdfe786f3530eca0d48fc7ed10/pkg%2Fkiosk%2Fazuread_login.go)                           | 54.5%    |
| [pkg/kiosk/grafana_com_login.go](https://github.com/grafana/grafana-kiosk/blob/5fcb2292c9aa29bdfe786f3530eca0d48fc7ed10/pkg%2Fkiosk%2Fgrafana_com_login.go)                   | 46.8%    |
| [pkg/kiosk/grafana_genericoauth_login.go](https://github.com/grafana/grafana-kiosk/blob/5fcb2292c9aa29bdfe786f3530eca0d48fc7ed10/pkg%2Fkiosk%2Fgrafana_genericoauth_login.go) | 47.7%    |
| [pkg/kiosk/grafana_idtoken_login.go](https://github.com/grafana/grafana-kiosk/blob/5fcb2292c9aa29bdfe786f3530eca0d48fc7ed10/pkg%2Fkiosk%2Fgrafana_idtoken_login.go)           | 2.6%     |
| [pkg/kiosk/local_login.go](https://github.com/grafana/grafana-kiosk/blob/5fcb2292c9aa29bdfe786f3530eca0d48fc7ed10/pkg%2Fkiosk%2Flocal_login.go)                               | 53.4%    |
| [pkg/kiosk/login_flow_utils.go](https://github.com/grafana/grafana-kiosk/blob/5fcb2292c9aa29bdfe786f3530eca0d48fc7ed10/pkg%2Fkiosk%2Flogin_flow_utils.go)                     | 77.7%    |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
