### PR TITLE
fix: browser flag validation and Edge binary fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to
 
 ### Bug Fixes
 
+- Fix browser validation blocking `-browser-path` escape hatch — validation now skipped when `BrowserPath` is set,
+  allowing arbitrary Chromium-based binaries via `-browser-path` regardless of `-browser` value
+- Fix silent Chrome fallback when Edge binary missing — startup now exits with a clear error message instead of
+  silently launching Chrome when `browser=edge` is set but no Edge binary is found on PATH
 - Fix azuread message loop missing `ctx.Done()` case — loop previously could not exit cleanly on shutdown
 - Remove dead `enableFetch` helper in idtoken login — no longer called after fetch setup moved to outer function
 - Fix goroutine panics in apikey and idtoken fetch interceptors — panics inside `go func()` blocks escape

--- a/pkg/cmd/grafana-kiosk/main.go
+++ b/pkg/cmd/grafana-kiosk/main.go
@@ -291,11 +291,18 @@ func main() {
 		os.Exit(-1)
 	}
 
-	// validate browser selection
-	switch strings.ToLower(cfg.General.Browser) {
-	case "", "chrome", "edge":
-	default:
-		log.Printf("Invalid browser %q — supported values: chrome, edge (or use -browser-path for a custom binary)", cfg.General.Browser)
+	// validate browser selection; skip when BrowserPath is set since it
+	// overrides Browser entirely and supports arbitrary Chromium binaries.
+	if cfg.General.BrowserPath == "" {
+		switch strings.ToLower(cfg.General.Browser) {
+		case "", "chrome", "edge":
+		default:
+			log.Printf("Invalid browser %q — supported values: chrome, edge (or use -browser-path for a custom binary)", cfg.General.Browser)
+			os.Exit(-1)
+		}
+	}
+	if err := kiosk.ValidateBrowserConfig(&cfg); err != nil {
+		log.Printf("Browser configuration error: %v", err)
 		os.Exit(-1)
 	}
 

--- a/pkg/kiosk/utils.go
+++ b/pkg/kiosk/utils.go
@@ -187,6 +187,25 @@ func resolveBrowserExecPath(cfg *Config) string {
 	return ""
 }
 
+// ValidateBrowserConfig returns an error if the browser configuration cannot
+// be satisfied: specifically when "edge" is requested but no Edge binary is
+// found on PATH and no explicit BrowserPath is set.
+func ValidateBrowserConfig(cfg *Config) error {
+	if cfg.General.BrowserPath != "" {
+		return nil
+	}
+	if strings.ToLower(cfg.General.Browser) != "edge" {
+		return nil
+	}
+	for _, name := range edgeBinaryCandidates {
+		if _, err := lookPath(name); err == nil {
+			return nil
+		}
+	}
+	return fmt.Errorf("browser 'edge' requested but no Edge binary found on PATH (tried: %v) — install Edge or use -browser-path to specify the executable",
+		edgeBinaryCandidates)
+}
+
 // isFullscreenMode reports whether the given kiosk mode requires fullscreen.
 // "full" and the empty default both mean fullscreen; "tv" and "disabled" do not.
 func isFullscreenMode(mode string) bool {

--- a/pkg/kiosk/utils_test.go
+++ b/pkg/kiosk/utils_test.go
@@ -721,3 +721,45 @@ func TestResolveBrowserExecPath(t *testing.T) {
 		})
 	})
 }
+
+func TestValidateBrowserConfig(t *testing.T) {
+	Convey("Given ValidateBrowserConfig", t, func() {
+		origLookPath := lookPath
+		defer func() { lookPath = origLookPath }()
+
+		Convey("Returns nil for chrome", func() {
+			cfg := &Config{General: General{Browser: "chrome"}}
+			So(ValidateBrowserConfig(cfg), ShouldBeNil)
+		})
+
+		Convey("Returns nil for empty browser (chromedp default)", func() {
+			cfg := &Config{General: General{Browser: ""}}
+			So(ValidateBrowserConfig(cfg), ShouldBeNil)
+		})
+
+		Convey("Returns nil when BrowserPath is set regardless of Browser", func() {
+			lookPath = func(string) (string, error) { return "", fmt.Errorf("not found") }
+			cfg := &Config{General: General{Browser: "edge", BrowserPath: "/custom/msedge"}}
+			So(ValidateBrowserConfig(cfg), ShouldBeNil)
+		})
+
+		Convey("Returns nil when edge binary found on PATH", func() {
+			lookPath = func(name string) (string, error) {
+				if name == "msedge" {
+					return "/usr/bin/msedge", nil
+				}
+				return "", fmt.Errorf("not found")
+			}
+			cfg := &Config{General: General{Browser: "edge"}}
+			So(ValidateBrowserConfig(cfg), ShouldBeNil)
+		})
+
+		Convey("Returns error when edge requested but no binary found", func() {
+			lookPath = func(string) (string, error) { return "", fmt.Errorf("not found") }
+			cfg := &Config{General: General{Browser: "edge"}}
+			err := ValidateBrowserConfig(cfg)
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldContainSubstring, "edge")
+		})
+	})
+}


### PR DESCRIPTION
Fixes #272

## Bug Fixes

- **Fix `-browser-path` escape hatch blocked by `-browser` validation** — when `BrowserPath` is set it overrides `Browser` entirely; validation now skipped in that case so `KIOSK_BROWSER=firefox KIOSK_BROWSER_PATH=/usr/bin/firefox` works correctly
- **Fix silent Chrome fallback when Edge binary missing** — added `ValidateBrowserConfig` called at startup; exits with a clear error message when `browser=edge` is set but no Edge binary found on PATH, instead of silently launching Chrome

## Tests

- Add `TestValidateBrowserConfig` covering: chrome, empty (chromedp default), BrowserPath override, edge found on PATH, edge not found
<!-- octocov -->
## Code Metrics Report
| Coverage | Code to Test Ratio | Test Execution Time |
|---------:|-------------------:|--------------------:|
| 50.6%    | 1:1.3              | 3m28s               |


### Code coverage of files in pull request scope (59.4%)

|                                                                            Files                                                                            | Coverage |
|-------------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|
| [pkg/cmd/grafana-kiosk/main.go](https://github.com/grafana/grafana-kiosk/blob/8cfe96003d44d90b1b7cb1827645fa40628df073/pkg%2Fcmd%2Fgrafana-kiosk%2Fmain.go) | 49.3%    |
| [pkg/kiosk/utils.go](https://github.com/grafana/grafana-kiosk/blob/8cfe96003d44d90b1b7cb1827645fa40628df073/pkg%2Fkiosk%2Futils.go)                         | 80.3%    |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
