### PR TITLE
fix: Edge browser support on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ and this project adheres to
 
 ### Bug Fixes
 
+- Fix Edge browser failing to start on Windows — pass `--edge-skip-compat-layer-relaunch` when Edge is detected on
+  Windows so chromedp can attach to the DevTools websocket
+- Fix Edge browser not found on Windows when `msedge.exe` is not on `PATH` — `ResolveBrowserExecPath` now also
+  checks standard Edge install locations under `%ProgramFiles(x86)%`, `%ProgramFiles%`, `%ProgramW6432%`
 - Fix browser validation blocking `-browser-path` escape hatch — validation now skipped when `BrowserPath` is set,
   allowing arbitrary Chromium-based binaries via `-browser-path` regardless of `-browser` value
 - Fix silent Chrome fallback when Edge binary missing — startup now exits with a clear error message instead of

--- a/pkg/kiosk/login/shared/chromedp_utils.go
+++ b/pkg/kiosk/login/shared/chromedp_utils.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -27,6 +29,19 @@ var EdgeBinaryCandidates = []string{
 
 // LookPath is overridable in tests.
 var LookPath = exec.LookPath
+
+// FileExists is overridable in tests. Returns true if path refers to an
+// existing file (not a directory).
+var FileExists = func(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}
+
+// GOOS is overridable in tests for cross-platform branches.
+var GOOS = runtime.GOOS
 
 // GenerateURL constructs URL with appropriate parameters for kiosk mode.
 func GenerateURL(cfg *config.Config) string {
@@ -209,11 +224,32 @@ func GenerateExecutorOptions(dir string, cfg *config.Config) []chromedp.ExecAllo
 		execAllocatorOption = append(execAllocatorOption, chromedp.ExecPath(path))
 	}
 
+	// Edge on Windows relaunches through a compatibility layer; the initial
+	// process exits immediately and chromedp never gets the DevTools websocket.
+	// Skip the relaunch so chromedp can attach.
+	if GOOS == "windows" && isEdgeBrowser(cfg) {
+		execAllocatorOption = append(execAllocatorOption,
+			chromedp.Flag("edge-skip-compat-layer-relaunch", true))
+	}
+
 	return execAllocatorOption
 }
 
-// ResolveBrowserExecPath returns the explicit browser executable path to pass to
-// chromedp.ExecPath. An empty string means "let chromedp auto-detect".
+// isEdgeBrowser reports whether cfg targets Microsoft Edge, either by the
+// Browser selector or by an explicit BrowserPath that names an Edge binary.
+func isEdgeBrowser(cfg *config.Config) bool {
+	if strings.ToLower(cfg.General.Browser) == "edge" {
+		return true
+	}
+	if p := cfg.General.BrowserPath; p != "" {
+		lower := strings.ToLower(filepath.Base(p))
+		if strings.Contains(lower, "msedge") || strings.Contains(lower, "microsoft-edge") {
+			return true
+		}
+	}
+	return false
+}
+
 // ResolveBrowserExecPath returns the explicit browser executable path to pass to
 // chromedp.ExecPath. An empty string means "let chromedp auto-detect".
 func ResolveBrowserExecPath(cfg *config.Config) string {
@@ -229,8 +265,31 @@ func ResolveBrowserExecPath(cfg *config.Config) string {
 				return p
 			}
 		}
+		if GOOS == "windows" {
+			if p := lookupEdgeOnWindows(); p != "" {
+				return p
+			}
+		}
 		log.Println("Browser 'edge' requested but no Edge binary found on PATH; set -browser-path or KIOSK_BROWSER_PATH to the Edge executable")
 		return ""
+	}
+	return ""
+}
+
+// lookupEdgeOnWindows checks the standard Edge install locations on Windows.
+// Returns the first existing msedge.exe path, or "" if none found.
+func lookupEdgeOnWindows() string {
+	envVars := []string{"ProgramFiles(x86)", "ProgramFiles", "ProgramW6432"}
+	const rel = `Microsoft\Edge\Application\msedge.exe`
+	for _, v := range envVars {
+		base := os.Getenv(v)
+		if base == "" {
+			continue
+		}
+		candidate := filepath.Join(base, rel)
+		if FileExists(candidate) {
+			return candidate
+		}
 	}
 	return ""
 }

--- a/pkg/kiosk/login/shared/chromedp_utils_test.go
+++ b/pkg/kiosk/login/shared/chromedp_utils_test.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -139,6 +140,68 @@ func TestResolveBrowserExecPathInShared(t *testing.T) {
 		Convey("Unknown Browser value returns empty", func() {
 			cfg := &config.Config{General: config.General{Browser: "firefox"}}
 			So(ResolveBrowserExecPath(cfg), ShouldEqual, "")
+		})
+
+		Convey("Browser=edge on Windows falls back to standard install location", func() {
+			origGOOS := GOOS
+			origFileExists := FileExists
+			defer func() { GOOS = origGOOS; FileExists = origFileExists }()
+			GOOS = "windows"
+			LookPath = func(string) (string, error) { return "", fmt.Errorf("not found") }
+			t.Setenv("ProgramFiles(x86)", `C:\Program Files (x86)`)
+			t.Setenv("ProgramFiles", "")
+			t.Setenv("ProgramW6432", "")
+			want := filepath.Join(`C:\Program Files (x86)`, `Microsoft\Edge\Application\msedge.exe`)
+			FileExists = func(p string) bool { return p == want }
+			cfg := &config.Config{General: config.General{Browser: "edge"}}
+			So(ResolveBrowserExecPath(cfg), ShouldEqual, want)
+		})
+
+		Convey("Browser=edge on Windows with no install location returns empty", func() {
+			origGOOS := GOOS
+			origFileExists := FileExists
+			defer func() { GOOS = origGOOS; FileExists = origFileExists }()
+			GOOS = "windows"
+			LookPath = func(string) (string, error) { return "", fmt.Errorf("not found") }
+			t.Setenv("ProgramFiles(x86)", `C:\Program Files (x86)`)
+			t.Setenv("ProgramFiles", `C:\Program Files`)
+			t.Setenv("ProgramW6432", `C:\Program Files`)
+			FileExists = func(string) bool { return false }
+			cfg := &config.Config{General: config.General{Browser: "edge"}}
+			So(ResolveBrowserExecPath(cfg), ShouldEqual, "")
+		})
+	})
+}
+
+func TestIsEdgeBrowser(t *testing.T) {
+	Convey("Given isEdgeBrowser", t, func() {
+		Convey("Browser=edge returns true", func() {
+			cfg := &config.Config{General: config.General{Browser: "edge"}}
+			So(isEdgeBrowser(cfg), ShouldBeTrue)
+		})
+		Convey("Browser=EDGE (case-insensitive) returns true", func() {
+			cfg := &config.Config{General: config.General{Browser: "EDGE"}}
+			So(isEdgeBrowser(cfg), ShouldBeTrue)
+		})
+		Convey("Browser=chrome returns false", func() {
+			cfg := &config.Config{General: config.General{Browser: "chrome"}}
+			So(isEdgeBrowser(cfg), ShouldBeFalse)
+		})
+		Convey("BrowserPath ending in msedge.exe returns true", func() {
+			cfg := &config.Config{General: config.General{BrowserPath: `C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe`}}
+			So(isEdgeBrowser(cfg), ShouldBeTrue)
+		})
+		Convey("BrowserPath containing microsoft-edge returns true", func() {
+			cfg := &config.Config{General: config.General{BrowserPath: "/usr/bin/microsoft-edge-stable"}}
+			So(isEdgeBrowser(cfg), ShouldBeTrue)
+		})
+		Convey("BrowserPath pointing to chrome returns false", func() {
+			cfg := &config.Config{General: config.General{BrowserPath: "/usr/bin/google-chrome"}}
+			So(isEdgeBrowser(cfg), ShouldBeFalse)
+		})
+		Convey("Empty config returns false", func() {
+			cfg := &config.Config{}
+			So(isEdgeBrowser(cfg), ShouldBeFalse)
 		})
 	})
 }

--- a/pkg/kiosk/utils.go
+++ b/pkg/kiosk/utils.go
@@ -10,18 +10,14 @@ import (
 
 // ValidateBrowserConfig returns an error if the browser configuration cannot
 // be satisfied: specifically when "edge" is requested but no Edge binary is
-// found on PATH and no explicit BrowserPath is set.
+// found on PATH, in standard Windows install locations, and no explicit
+// BrowserPath is set.
 func ValidateBrowserConfig(cfg *config.Config) error {
-	if cfg.General.BrowserPath != "" {
+	if strings.ToLower(cfg.General.Browser) != "edge" || cfg.General.BrowserPath != "" {
 		return nil
 	}
-	if strings.ToLower(cfg.General.Browser) != "edge" {
+	if shared.ResolveBrowserExecPath(cfg) != "" {
 		return nil
-	}
-	for _, name := range shared.EdgeBinaryCandidates {
-		if _, err := shared.LookPath(name); err == nil {
-			return nil
-		}
 	}
 	return fmt.Errorf("browser 'edge' requested but no Edge binary found on PATH (tried: %v) — install Edge or use -browser-path to specify the executable",
 		shared.EdgeBinaryCandidates)


### PR DESCRIPTION
- Pass --edge-skip-compat-layer-relaunch when Edge is detected on Windows so chromedp can attach to the DevTools websocket; without it Edge relaunches through a compatibility layer and the initial process exits before the websocket is ready.
- Add isEdgeBrowser helper that detects Edge via Browser=='edge' or a BrowserPath whose basename contains msedge/microsoft-edge.
- ResolveBrowserExecPath now falls back to standard Edge install locations on Windows (%ProgramFiles(x86)%, %ProgramFiles%, %ProgramW6432%) when LookPath fails.
- Add overridable FileExists and GOOS vars for testability.
- Simplify ValidateBrowserConfig to delegate to ResolveBrowserExecPath instead of duplicating the PATH-only check.