### PR TITLE
fix: browser startup timeout, drop coverage badge, fix action-update docs

### DIFF
--- a/.agents/ci.md
+++ b/.agents/ci.md
@@ -70,10 +70,14 @@ requires a newer Go than the image was built with.
 3. **Compare SHAs** — If a newer version exists, get its commit SHA:
 
    ```sh
-   gh api repos/<owner>/<repo>/git/ref/tags/<tag> --jq '.object.sha'
+   gh api repos/<owner>/<repo>/commits/<tag> --jq '.sha'
    ```
 
    Compare against the SHA currently pinned in the workflow file.
+
+   Do not use `git/ref/tags/<tag>`. For an annotated tag that returns the tag
+   object's SHA, not the commit's, so correctly pinned actions look stale.
+   `commits/<tag>` dereferences to the commit either way.
 
 4. **Update the workflow file** — Replace the old SHA and version comment
    with the new SHA and version tag. Always use the full 40-character

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: write      # badge branch push, releases
+      contents: write      # releases
       pull-requests: write # octocov PR body insertion
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -77,34 +77,6 @@ jobs:
 
       - name: Report coverage
         uses: k1LoW/octocov-action@a167dc0dee441b7ffc45e1b862ab55ec0d87f278 # v1.5.2
-
-      - name: Push coverage badge endpoint
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        run: |
-          # Extract coverage percentage
-          COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | tr -d '%')
-          # Pick color based on coverage
-          if (( $(echo "$COVERAGE >= 80" | bc -l) )); then COLOR="brightgreen"
-          elif (( $(echo "$COVERAGE >= 60" | bc -l) )); then COLOR="yellow"
-          else COLOR="red"; fi
-          # Build shields.io endpoint JSON
-          mkdir -p /tmp/badges
-          cat > /tmp/badges/coverage.json <<BADGE
-          {"schemaVersion":1,"label":"coverage","message":"${COVERAGE}%","color":"${COLOR}"}
-          BADGE
-          # Push to badges branch
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout --orphan badges
-          git rm -rf .
-          mkdir -p badges
-          cp /tmp/badges/coverage.json badges/
-          git add badges/
-          git commit -m "Update coverage badge"
-          git push origin badges --force
-          git checkout "${{ github.sha }}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload coverage report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to
 - Fix ID token login occasionally letting requests through without the configured token attached
 - Fix silent exits on bad config — startup validation failures now log a descriptive message with a fix
   suggestion before exiting
+- Fix startup failures on slow or busy devices — the browser is now given 60 seconds instead of 20 to come up,
+  so a cold start on hardware like a Raspberry Pi no longer aborts the session and forces a restart
 - Speed up Azure AD and Grafana Cloud login by 3 seconds each — fixed delays replaced with waits that continue as
   soon as the page is ready
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fgrafana%2Fgrafana-kiosk%2Fbadge%3Fref%3Dmain&style=flat)](https://actions-badge.atrox.dev/grafana/grafana-kiosk/goto?ref=main)
 [![Go Report Card](https://goreportcard.com/badge/github.com/grafana/grafana-kiosk)](https://goreportcard.com/report/github.com/grafana/grafana-kiosk)
-![coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/grafana/grafana-kiosk/badges/badges/coverage.json)
 
 A very useful feature of Grafana is the ability to display dashboards and playlists on a large TV.
 

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -24,6 +24,7 @@
     "Ronan",
     "Stäheli",
     "TOPNAV",
+    "WSURL",
     "XAUTHORITY",
     "apikey",
     "armv",

--- a/pkg/kiosk/integration/helpers_test.go
+++ b/pkg/kiosk/integration/helpers_test.go
@@ -107,10 +107,37 @@ func tempDir(t *testing.T) string {
 	return dir
 }
 
+// browserStartAttempts is how many times to try launching the browser before
+// failing the test. The kiosk binary absorbs a failed launch in its restart
+// loop; tests have no such loop, so without a retry a Chromium that starts
+// slowly or crashes on a busy machine fails the whole run.
+const browserStartAttempts = 3
+
 // newHeadlessBrowserContext creates a chromedp task context using the same
 // options as the kiosk (headless, same browser path).
 func newHeadlessBrowserContext(t *testing.T, cfg *config.Config, dir string) (context.Context, context.CancelFunc) {
 	t.Helper()
-	taskCtx, cancel := shared.NewBrowserContext(context.Background(), cfg, dir, 0)
-	return taskCtx, cancel
+	for attempt := 1; ; attempt++ {
+		taskCtx, cancel, err := tryNewBrowserContext(cfg, dir)
+		if err == nil {
+			return taskCtx, cancel
+		}
+		if attempt == browserStartAttempts {
+			t.Fatalf("start browser after %d attempts: %v", attempt, err)
+		}
+		t.Logf("browser start attempt %d/%d failed, retrying: %v", attempt, browserStartAttempts, err)
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// tryNewBrowserContext turns NewBrowserContext's panic into an error so the
+// caller can retry.
+func tryNewBrowserContext(cfg *config.Config, dir string) (taskCtx context.Context, cancel context.CancelFunc, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("browser start panicked: %v", r)
+		}
+	}()
+	taskCtx, cancel = shared.NewBrowserContext(context.Background(), cfg, dir, 0)
+	return taskCtx, cancel, nil
 }

--- a/pkg/kiosk/login/shared/chromedp_utils.go
+++ b/pkg/kiosk/login/shared/chromedp_utils.go
@@ -28,6 +28,10 @@ var EdgeBinaryCandidates = []string{
 // LookPath is overridable in tests.
 var LookPath = exec.LookPath
 
+// browserStartupTimeout is how long to wait for Chromium to print its DevTools
+// websocket URL before giving up on the launch.
+const browserStartupTimeout = 60 * time.Second
+
 // GenerateURL constructs URL with appropriate parameters for kiosk mode.
 func GenerateURL(cfg *config.Config) string {
 	parsedURI, _ := url.ParseRequestURI(cfg.Target.URL)
@@ -94,6 +98,11 @@ func GenerateExecutorOptions(dir string, cfg *config.Config) []chromedp.ExecAllo
 	}
 
 	execAllocatorOption := []chromedp.ExecAllocatorOption{
+		// Wait longer than chromedp's 20s default for the browser to report its
+		// DevTools websocket URL. A cold Chromium start on a low-powered device
+		// or a loaded machine can exceed 20s, and missing the deadline aborts
+		// startup entirely.
+		chromedp.WSURLReadTimeout(browserStartupTimeout),
 		// Skip first-run wizard and default browser prompt on startup.
 		chromedp.NoFirstRun,
 		chromedp.NoDefaultBrowserCheck,
@@ -212,8 +221,6 @@ func GenerateExecutorOptions(dir string, cfg *config.Config) []chromedp.ExecAllo
 	return execAllocatorOption
 }
 
-// ResolveBrowserExecPath returns the explicit browser executable path to pass to
-// chromedp.ExecPath. An empty string means "let chromedp auto-detect".
 // ResolveBrowserExecPath returns the explicit browser executable path to pass to
 // chromedp.ExecPath. An empty string means "let chromedp auto-detect".
 func ResolveBrowserExecPath(cfg *config.Config) string {


### PR DESCRIPTION
### Bug Fixes

- Give the browser 60s to start instead of chromedp's 20s default. A cold Chromium start on a Raspberry Pi or a
  loaded machine can exceed 20s, which aborted the session and cost a `-restart-delay-ms` cycle to recover.

### CI/CD

- Dropped the coverage badge step. It force-pushed to the orphan `badges` branch, which requires verified
  signatures, so the runner's unsigned commit was rejected with `GH013` and failed `build` on every push to
  `main`. octocov still reports coverage in the PR comment and job summary.
- Retry the browser launch up to 3x in the integration helper. `NewBrowserContext` panics on a failed launch,
  which the kiosk absorbs in its restart loop but tests do not — one CI run in 25 flaked on exactly this.

### Documentation

- Removed the now-dataless coverage badge from `README.md`.
- Fixed `.agents/ci.md`: use `commits/<tag>` not `git/ref/tags/<tag>` to read an action's pinned SHA. The latter
  returns the tag object for annotated tags, making correct pins look stale.

Verified locally: build, unit tests, `golangci-lint`, `gosec`, `markdownlint`, `cspell` all clean; integration
suite 4/4. Retry path exercised by pointing `KIOSK_BROWSER_PATH` at a nonexistent binary.

Fixes: https://github.com/grafana/grafana-kiosk/actions/runs/34230366913/job/102074678159

<!-- octocov -->
## Code Metrics Report
| Coverage | Code to Test Ratio | Test Execution Time |
|---------:|-------------------:|--------------------:|
| 50.5%    | 1:1.2              | 16s                 |


### Code coverage of files in pull request scope (38.3%, patch 0.0%)

|                                                                                        Files                                                                                        | Coverage | Patch Coverage |
|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------:|---------------:|
| [pkg/kiosk/login/shared/chromedp_utils.go](https://github.com/grafana/grafana-kiosk/blob/7568b1afd1daee4ba8668c2db81f40a1ec2cf87b/pkg%2Fkiosk%2Flogin%2Fshared%2Fchromedp_utils.go) | 38.3%    | 0.0%           |

---
Reported by [octocov](https://github.com/k1LoW/octocov)
<!-- octocov -->
